### PR TITLE
feat(T031): Implement and verify CNN workload

### DIFF
--- a/ia_risc_v_npu/specs/001-ia-risc-v/tasks.md
+++ b/ia_risc_v_npu/specs/001-ia-risc-v/tasks.md
@@ -67,7 +67,10 @@
 - [x] T030: Implement a more advanced ROI detection mechanism.
 
 ### Week 11: Workload Analysis
-- [ ] T031: [P] Run the simulator with a variety of workloads (e.g., CNN layers).
+- [/] T031: [P] Run the simulator with a variety of workloads (e.g., CNN layers).
+  - [x] Create a test to run the generated CNN workload.
+  - [x] Parametrize the CNN workload test to run with a variety of configurations.
+  - [x] Add result verification to the CNN workload test.
 - [ ] T032: Analyze the accuracy and performance of the simulator against the goals in `prd.md`.
 
 ### Week 12: Finalization

--- a/ia_risc_v_npu/src/risc_v/instructions/alu.py
+++ b/ia_risc_v_npu/src/risc_v/instructions/alu.py
@@ -12,3 +12,6 @@ def or_(a, b):
 
 def xor(a, b):
     return a ^ b
+
+def fmadd(a, b, c):
+    return a * b + c

--- a/ia_risc_v_npu/src/risc_v/instructions/memory.py
+++ b/ia_risc_v_npu/src/risc_v/instructions/memory.py
@@ -1,11 +1,11 @@
-def ld(memory, address):
-    return int.from_bytes(memory[address:address+8], 'little')
+def ld(bus, address):
+    return int.from_bytes(bus.read(address, 8), 'little')
 
-def sd(memory, address, value):
-    memory[address:address+8] = value.to_bytes(8, 'little')
+def sd(bus, address, value):
+    bus.write(address, value.to_bytes(8, 'little'))
 
-def lw(memory, address):
-    return int.from_bytes(memory[address:address+4], 'little')
+def lw(bus, address):
+    return int.from_bytes(bus.read(address, 4), 'little')
 
-def sw(memory, address, value):
-    memory[address:address+4] = value.to_bytes(4, 'little')
+def sw(bus, address, value):
+    bus.write(address, value.to_bytes(4, 'little'))

--- a/ia_risc_v_npu/src/simulator/main.py
+++ b/ia_risc_v_npu/src/simulator/main.py
@@ -44,7 +44,10 @@ class AdaptiveSimulator:
         while not self.halt:
             if max_cycles > 0 and cycles >= max_cycles:
                 break
-            inst_result = self.risc_v_engine.execute_instruction()
+            status = self.risc_v_engine.execute_instruction()
+            if status == "halt":
+                self.halt = True
+                break
             # For now, we'll just use the timing hooks for latency
             latency = self.timing_hooks.fetch_hook(0, 0) # dummy values
             self.sim_time += latency

--- a/ia_risc_v_npu/tests/integration/test_cnn_workload.py
+++ b/ia_risc_v_npu/tests/integration/test_cnn_workload.py
@@ -3,22 +3,36 @@ import numpy as np
 from src.simulator.main import AdaptiveSimulator
 from workloads.cnn_workload import generate_cnn_workload
 
-@pytest.mark.parametrize("channels, height, width, kernel_size", [
-    (1, 3, 3, 2),
-    (2, 4, 4, 2),
-    (1, 5, 5, 3),
+# Register ABI names for clarity
+REG_T0 = 5 # input_addr_reg
+REG_T1 = 6 # weight_addr_reg
+REG_T2 = 7 # output_addr_reg
+
+@pytest.mark.parametrize("input_shape, kernel_shape", [
+    ((1, 3, 3), (1, 2, 2)),
+    ((2, 4, 4), (2, 2, 2)),
+    ((1, 5, 5), (1, 3, 3)),
 ])
 @pytest.mark.asyncio
-async def test_run_cnn_workload_with_verification(channels, height, width, kernel_size):
+async def test_run_cnn_workload_with_verification(input_shape, kernel_shape):
     """
-    Tests running a generated CNN workload on the simulator and verifies the results.
+    Tests running a generated 2D CNN workload on the simulator and verifies the results.
     """
     # 1. Generate test data
-    input_data = np.arange(1, channels * height * width + 1, dtype=np.uint32)
-    weights = np.arange(1, channels + 1, dtype=np.uint32)
+    channels, height, width = input_shape
+    _, kernel_height, kernel_width = kernel_shape
+    input_data = np.arange(1, channels * height * width + 1, dtype=np.uint32).reshape(input_shape)
+    weights = np.arange(1, channels * kernel_height * kernel_width + 1, dtype=np.uint32).reshape(kernel_shape)
 
     # 2. Generate the CNN workload
-    workload = generate_cnn_workload(channels, height, width, kernel_size)
+    reg_config = {
+        'input_addr': REG_T0,
+        'weight_addr': REG_T1,
+        'output_addr': REG_T2,
+    }
+    workload = generate_cnn_workload(input_shape, kernel_shape, reg_config)
+    # Add a halt instruction (JAL x0, 0) to the end
+    workload.append(0x0000006F)
 
     # 3. Initialize the simulator and memory
     simulator = AdaptiveSimulator()
@@ -26,41 +40,40 @@ async def test_run_cnn_workload_with_verification(channels, height, width, kerne
     weights_addr = 0x2000
     output_addr = 0x3000
 
-    simulator.risc_v_engine.registers[5] = input_addr
-    simulator.risc_v_engine.registers[6] = weights_addr
-    simulator.risc_v_engine.registers[4] = output_addr
+    simulator.risc_v_engine.registers[REG_T0] = input_addr
+    simulator.risc_v_engine.registers[REG_T1] = weights_addr
+    simulator.risc_v_engine.registers[REG_T2] = output_addr
 
     # Write input and weights to memory
-    for i, val in enumerate(input_data):
-        simulator.bus.write(input_addr + i * 4, val.tobytes())
-    for i, val in enumerate(weights):
-        simulator.bus.write(weights_addr + i * 4, val.tobytes())
+    simulator.bus.write(input_addr, input_data.tobytes())
+    simulator.bus.write(weights_addr, weights.tobytes())
 
     # 4. Load and run the program
     simulator.load_program(workload)
-    await simulator.run_simulation(max_cycles=len(workload))
+    # Run with a generous cycle limit, relying on the halt instruction
+    await simulator.run_simulation(max_cycles=len(workload) * 10)
 
     # 5. Calculate expected output
-    output_height = height - kernel_size + 1
-    output_width = width - kernel_size + 1
+    output_height = height - kernel_height + 1
+    output_width = width - kernel_width + 1
     expected_output = np.zeros((output_height, output_width), dtype=np.uint32)
     for i in range(output_height):
         for j in range(output_width):
             acc = 0
-            for k in range(channels):
-                input_val = input_data[i * width + j + k]
-                weight_val = weights[k]
-                acc += input_val * weight_val
+            for c in range(channels):
+                for ky in range(kernel_height):
+                    for kx in range(kernel_width):
+                        input_val = input_data[c, i + ky, j + kx]
+                        weight_val = weights[c, ky, kx]
+                        acc += input_val * weight_val
             expected_output[i, j] = acc
 
     # 6. Read output from memory and verify
-    for i in range(output_height):
-        for j in range(output_width):
-            offset = (i * output_width + j) * 4
-            result_bytes = simulator.bus.read(output_addr + offset, 4)
-            result = np.frombuffer(result_bytes, dtype=np.uint32)[0]
-            assert result == expected_output[i, j]
+    output_size_bytes = expected_output.nbytes
+    result_bytes = simulator.bus.read(output_addr, output_size_bytes)
+    result = np.frombuffer(result_bytes, dtype=np.uint32).reshape(expected_output.shape)
+    np.testing.assert_array_equal(result, expected_output)
 
-    # Also check the PC
-    expected_pc = len(workload) * 4
+    # Also check the PC to ensure it halted at the last instruction
+    expected_pc = len(workload) * 4 - 4
     assert simulator.risc_v_engine.pc == expected_pc

--- a/ia_risc_v_npu/tests/integration/test_cnn_workload.py
+++ b/ia_risc_v_npu/tests/integration/test_cnn_workload.py
@@ -1,0 +1,66 @@
+import pytest
+import numpy as np
+from src.simulator.main import AdaptiveSimulator
+from workloads.cnn_workload import generate_cnn_workload
+
+@pytest.mark.parametrize("channels, height, width, kernel_size", [
+    (1, 3, 3, 2),
+    (2, 4, 4, 2),
+    (1, 5, 5, 3),
+])
+@pytest.mark.asyncio
+async def test_run_cnn_workload_with_verification(channels, height, width, kernel_size):
+    """
+    Tests running a generated CNN workload on the simulator and verifies the results.
+    """
+    # 1. Generate test data
+    input_data = np.arange(1, channels * height * width + 1, dtype=np.uint32)
+    weights = np.arange(1, channels + 1, dtype=np.uint32)
+
+    # 2. Generate the CNN workload
+    workload = generate_cnn_workload(channels, height, width, kernel_size)
+
+    # 3. Initialize the simulator and memory
+    simulator = AdaptiveSimulator()
+    input_addr = 0x1000
+    weights_addr = 0x2000
+    output_addr = 0x3000
+
+    simulator.risc_v_engine.registers[5] = input_addr
+    simulator.risc_v_engine.registers[6] = weights_addr
+    simulator.risc_v_engine.registers[4] = output_addr
+
+    # Write input and weights to memory
+    for i, val in enumerate(input_data):
+        simulator.bus.write(input_addr + i * 4, val.tobytes())
+    for i, val in enumerate(weights):
+        simulator.bus.write(weights_addr + i * 4, val.tobytes())
+
+    # 4. Load and run the program
+    simulator.load_program(workload)
+    await simulator.run_simulation(max_cycles=len(workload))
+
+    # 5. Calculate expected output
+    output_height = height - kernel_size + 1
+    output_width = width - kernel_size + 1
+    expected_output = np.zeros((output_height, output_width), dtype=np.uint32)
+    for i in range(output_height):
+        for j in range(output_width):
+            acc = 0
+            for k in range(channels):
+                input_val = input_data[i * width + j + k]
+                weight_val = weights[k]
+                acc += input_val * weight_val
+            expected_output[i, j] = acc
+
+    # 6. Read output from memory and verify
+    for i in range(output_height):
+        for j in range(output_width):
+            offset = (i * output_width + j) * 4
+            result_bytes = simulator.bus.read(output_addr + offset, 4)
+            result = np.frombuffer(result_bytes, dtype=np.uint32)[0]
+            assert result == expected_output[i, j]
+
+    # Also check the PC
+    expected_pc = len(workload) * 4
+    assert simulator.risc_v_engine.pc == expected_pc


### PR DESCRIPTION
This commit progresses task T031 by implementing a test for the CNN workload and verifying its correctness.

- tests/integration/test_cnn_workload.py:
  - Adds a new integration test to run a generated CNN workload on the simulator.
  - The test is parametrized to run with a variety of CNN configurations.
  - Includes result verification by comparing the simulator's output with a Python-based calculation.

- src/risc_v/instructions/memory.py:
  - Fixes a bug where memory instructions were incorrectly using slicing on the bus object. They now use the read and write methods.

- src/risc_v/instructions/alu.py:
  - Adds the missing fmadd instruction.

- specs/001-ia-risc-v/tasks.md:
  - Updates the task list to reflect the progress on T031.