### PR TITLE
Feature/t032 analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+The active code base resides in `ia_risc_v_npu/src`, with architecture-specific logic in `risc_v/`, accelerator models in `npu/`, and orchestration utilities in `simulator/`. Shared documents live in `docs/` and `specs/` (requirements, roadmap, performance notes). Scenario generators and reference inputs belong under `workloads/`. Tests mirror the runtime layout: `tests/unit` for pure functions, `tests/integration` for multi-component flows, `tests/performance` and `tests/verification` for benchmarking and golden-model checks. Keep new assets alongside the closest existing module to simplify discovery.
+
+## Build, Test, and Development Commands
+- `pip install -r ia_risc_v_npu/requirements.txt` installs the minimal dev stack.
+- `python -m src.simulator.cli simulate <path/to/program.elf> --config <path/to/config.json>` runs an ELF workload; store configs next to the workload you are exercising.
+- `python -m src.simulator.cli benchmark --instructions 200000` measures wall-clock throughput and reports MIPS so you can check the 12–20 MIPS target.
+- `pytest` runs the entire suite; use `pytest tests/unit -vv` before opening reviews for faster iteration.
+- `pytest tests/performance --benchmark-only` is reserved for profiling regressions; run it before merging any timing-sensitive change.
+
+## Coding Style & Naming Conventions
+Python code follows 4-space indentation, `black`/`ruff` with an 88 character line limit (`pyproject.toml`). Keep modules snake_case, classes PascalCase, async coroutines suffixed `_async` when disambiguation helps. Prefer type hints on public APIs and keep simulator hooks documented with short docstrings. Data files and workloads should use descriptive, kebab-cased filenames.
+
+## Testing Guidelines
+Add or update unit tests whenever you touch `src/`. Integration tests should cover cross-module behavior (e.g., simulator ↔ NPU handoff). Use `pytest.mark.asyncio` for coroutine tests and isolate slow cases with `@pytest.mark.performance`. Provide fixtures for any new sample programs, and refresh golden outputs under `tests/verification` when logic changes. Never skip performance tests if you modify latency models.
+
+## Commit & Pull Request Guidelines
+Commits follow Conventional Commits (`feat(simulator): ...`, `fix(riscv): ...`). Limit each commit to one logical change and ensure passing tests beforehand. PRs need a concise summary, links to roadmap tasks, and evidence for results: include benchmark diffs or console snippets when relevant. Tag reviewers familiar with the touched subsystem and note config requirements in the description.
+
+## Configuration & Security Tips
+Store experimental configs outside version control when possible; scrub secrets before sharing traces. The simulator reads JSON configs at runtime, so validate schema changes against existing workloads. Avoid committing large binary traces—reference them via reproducible scripts under `workloads/`.

--- a/README.md
+++ b/README.md
@@ -49,13 +49,23 @@ The adaptive core uses a combination of timing hooks for fast, high-level latenc
 
 ### Running the Simulator
 
-The main entry point for the simulator is `src/simulator/main.py`.
+Use the CLI entry point to execute an ELF workload.
 
 ```bash
-python src/simulator/main.py
+python -m src.simulator.cli simulate build/program.elf --config configs/example.json --output results/summary.json
 ```
 
-*Note: The simulator currently expects a `config.json` file in the execution directory.*
+*Note: The simulator expects a RISC-V ELF binary; configuration is optional but accepted via `--config`.*
+
+### Measuring Performance (T032)
+
+Benchmark wall-clock throughput and capture MIPS metrics.
+
+```bash
+python -m src.simulator.cli benchmark --instructions 200000 --output results/benchmark.json
+```
+
+The written JSON includes executed instruction count, elapsed seconds, and calculated MIPS so you can compare against the 12–20 MIPS goal.
 
 ## 5. Technology Stack
 

--- a/ia_risc_v_npu/.gitignore
+++ b/ia_risc_v_npu/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 # Profiling results
 *.pstats
 *.lprof
+profile.out
+test_output.log

--- a/ia_risc_v_npu/docs/prd.md
+++ b/ia_risc_v_npu/docs/prd.md
@@ -1,0 +1,835 @@
+# IA 기반 RISC-V+NPU 적응형 시뮬레이터 PRD v1.0
+
+---
+
+## 1. 프로젝트 개요
+
+## 1.1 프로젝트 목적
+
+- IA 기반 RISC-V+NPU 하이브리드 시뮬레이터 핵심 기능을 실시간 협업 개발로 3개월 MVP 완성
+- 기존 사이클 정확 시뮬레이터의 속도 한계 극복
+
+## 1.2 바이브코딩 접근법
+
+- **실시간 협업**: 즉시 피드백
+- **점진적 구현**: 매일 실행 버전
+- **지속적 검증**: 동시 테스트
+- **빠른 반복**: 주간 기능 완성
+
+## 1.3 비즈니스 목표
+
+- **검증 가능 프로토타입**
+- **성능 향상**: 기존 대비 50-200배
+- **시뮬레이션 속도**: 10-20 MIPS
+- **기본 정확도**: ±15% 이내
+- **확장성**: 고도화 가능
+
+---
+
+## 2. 시스템 아키텍처
+
+## 2.1 전체 구조
+
+`text┌───────────────┐
+│ CLI & Config  │
+│ Manager, Loader, Results │
+└──────────────────────────
+      ▼
+┌──────────────────────────┐
+│ Adaptive Simulator Core  │
+│ RISC-V IA, Events, Adaptive Controller │
+│ Fidelity Control (Lev0↔Lev1), Timing Hook Aggregator, Event Manager (asyncio) │
+└──────────────────────────┘
+      ▼
+┌──────────────────────────┐
+│ Hardware Models          │
+│ NPU Model, Memory System │
+│ Bus/Interconnect         │
+└──────────────────────────┘`
+
+## 2.2 RISC-V IA와 이벤트 연동
+
+`textPC = 0x1000
+▼
+FETCH ─► fetch_hook(pc, inst)         # I-cache 체크, latency log  
+▼
+DECODE ─► decode_hook(inst)           # complexity 분석
+▼
+EXECUTE ─► execute_hook(op)           # Lev0/Lev1 선택, 이벤트 트리거
+▼
+PC = PC + 4
+▼
+latency_predict()                     # Table lookup/hook or async sim`
+
+## 2.3 적응형 충실도 흐름
+
+`textInstruction Ready
+▼
+Complexity Analysis
+▼
+Uncertainty > Threshold? ─► No ─► LEV0 (Hook Path) ~10-20 MIPS  
+               │
+              Yes
+               ▼
+           ROI Detected? ─► No ─► continue  
+               │
+              Yes
+               ▼
+           LEV1 (Event Path) ~3-8 MIPS  
+               ▼
+           Update Hook Coefficients
+               ▼
+           Continue Next Instruction`
+
+---
+
+## 3. 기능 요구사항 (최적화 바이브코딩)
+
+## 3.1 핵심 기능 요구사항 (MVP)
+
+## 3.1.1 RISC-V IA 엔진 (필수)
+
+- **RV64I 명령어 구현 주간별 우선순위**
+    - Week 1-2: 기본 ALU (ADD, SUB, AND, OR, XOR)
+    - Week 3-4: 메모리 접근 (LD, SD, LW, SW)
+    - Week 5-6: 분기 명령 (BEQ, BNE, JAL, JALR)
+    - Week 7-8: 곱셈/나눗셈 (MUL, DIV)
+
+## 3.1.2 2레벨 적응형 모델 (핵심)
+
+- **충실도 레벨**
+    - Lev0(Fast): 타이밍 훅 및 테이블(80%, 15-20 MIPS)
+    - Lev1(Accurate): 이벤트 기반 분석(20%, 3-8 MIPS)
+
+## 3.1.3 기본 NPU 모델링 (필수)
+
+- **단계별 구현**
+    - Week 1-3: 단일코어 GEMM
+    - Week 4-6: 벡터 유닛
+    - Week 7-9: 로컬 메모리 모델(SPM)
+    - Week 10-12: MMIO 인터페이스
+
+---
+
+## 3.2 Timing Hook vs Event System
+
+## 3.2.1 타이밍 훅 시스템 (Lev0)
+
+`pythonclass TimingHookSystem:
+    def __init__(self):
+        self.hook_stats = {
+            'fetch': RingBuffer(1000),
+            'decode': RingBuffer(1000),
+            'execute': RingBuffer(1000),
+            'memory': RingBuffer(1000)
+        }
+
+    def fetch_hook(self, pc, inst_bits):
+        timestamp = time.time()
+        cache_miss = self._check_icache_miss(pc)
+        latency = 1 if not cache_miss else 10
+        self.hook_stats['fetch'].append({
+            'timestamp': timestamp,
+            'latency': latency,
+            'cache_miss': cache_miss
+        })
+        return latency
+
+    def predict_latency_lev0(self, operation):
+        *# Lev0 예측: 테이블 기반* 
+        base_latency = self.lookup_table[operation.opcode]
+        queue_penalty = self._calculate_queue_penalty()
+        conflict_adj = self._calculate_conflict_adjustment()
+        return base_latency + queue_penalty + conflict_adj`
+
+## 3.2.2 이벤트 기반 시스템 (Lev1)
+
+`pythonimport asyncio
+
+class EventBasedSystem:
+    def __init__(self):
+        self.bus_arbiter = BusArbiter()
+        self.dram_controller = DRAMController()
+        self.npu_engines = [NPUEngine(i) for i in range(4)]
+
+    async def predict_latency_lev1(self, operation):
+        await self.bus_arbiter.acquire()
+        bus_latency = await self.simulate_bus_transfer(operation)
+        if operation.needs_dram:
+            dram_latency = await self.dram_controller.access(operation.address)
+        else:
+            dram_latency = 0
+        if operation.is_npu_op:
+            npu_latency = await self._schedule_npu_execution(operation)
+        else:
+            npu_latency = 0
+        self.bus_arbiter.release()
+        return bus_latency + dram_latency + npu_latency`
+
+---
+
+## 3.3 성능 요구사항 및 예측
+
+| **메트릭** | **Week 4 목표** | **Week 8 목표** | **Week 12 목표** |
+| --- | --- | --- | --- |
+| 시뮬레이션 속도 | 5-8 MIPS | 8-12 MIPS | 12-20 MIPS |
+| Cycle 대비 속도 | 20배 | 50배 | 100배 |
+| 정확도 | ±25% | ±20% | ±15% |
+| 메모리 사용량 | 6GB | 5GB | 4GB |
+| 코드 커버리지 | 50% | 65% | 70% |
+
+---
+
+## 4. 바이브코딩 개발 로드맵 (12주)
+
+## Phase 1: 기반 엔진 (1-4주)
+
+- Week 1: 프로젝트 세팅, 기본 IA 엔진, 타이밍 훅, 고정테이블 구현
+- Week 2: ALU + 훅 통계, 단위/통합 테스트
+- Week 3: 메모리 접근 및 훅
+- Week 4: 분기명령, 성능 측정
+
+## Phase 2: NPU + 이벤트 시스템 (5-8주)
+
+- Week 5: NPU 모델, MMIO, asyncio 구성
+- Week 6: 레벨 전환, 분류기, 적응형 테스트
+- Week 7: 벡터연산, SPM/버스 모델
+- Week 8: 최적화, 벡터화, 병목 프로파일링
+
+## Phase 3: 통합 및 검증 (9-12주)
+
+- Week 9: 시스템 통합, 워크로드 테스트
+- Week 10: 메모리 최적화, ROI
+- Week 11: 다양한 워크로드, 정확도·속도 분석
+- Week 12: 문서, API, 최종 벤치마킹
+
+---
+
+## 5. 기술 스펙 및 상세 구현
+
+## 5.1 개발 환경 및 도구
+
+- VS Code Live Share
+- Discord/Slack
+- GitHub + CI/CD
+- pytest-watch
+- cProfile, memory_profiler, pytest-benchmark, line_profiler
+
+## 5.2 핵심 클래스 예시
+
+## AdaptiveSimulator
+
+`pythonclass AdaptiveSimulator:
+    def __init__(self, config_path: str):
+        self.risc_v_engine = RISCVEngine()
+        self.timing_hooks = TimingHookSystem()
+        self.event_system = EventBasedSystem()
+        self.fidelity_controller = FidelityController()
+    def run_simulation(self) -> SimulationResult:
+        while not self.halt:
+            inst_result = self.risc_v_engine.execute_instruction()
+            if self.fidelity_controller.should_use_lev1(inst_result):
+                latency = await self.event_system.predict_latency_lev1(inst_result)
+            else:
+                latency = self.timing_hooks.predict_latency_lev0(inst_result)
+            self.sim_time += latency
+        return SimulationResult(...)`
+
+## RISCVEngine
+
+`pythonclass RISCVEngine:
+    def __init__(self):
+        self.decoder = RISCVDecoder()
+        self.state = ProcessorState()
+        self.complexity_classifier = ComplexityClassifier()
+    def execute_instruction(self) -> InstructionResult:
+        inst_bits = self.fetch(self.state.pc)
+        fetch_latency = self.timing_hooks.fetch_hook(self.state.pc, inst_bits)
+        decoded = self.decoder.decode(inst_bits)
+        decode_latency = self.timing_hooks.decode_hook(decoded)
+        result = self._execute_functional(decoded)
+        execute_latency = self.timing_hooks.execute_hook(decoded, result)
+        self._commit_state(result)
+        return InstructionResult(
+            instruction=decoded,
+            result=result,
+            complexity=self.complexity_classifier.classify(decoded),
+            base_latency=fetch_latency + decode_latency + execute_latency
+        )`
+
+---
+
+## 6. 시뮬레이션 성능 및 최적화
+
+## 6.1 기준점 비교
+
+기존 시뮬레이터
+
+- gem5(사이클 정확): 0.01-0.3 MIPS
+- SESC: ~0.02 MIPS
+- QEMU: 50-200+ MIPS
+- RISC-V Virtual Prototype: 27-32 MIPS
+- 컴파일드 시뮬레이터: ~10 MIPS
+
+목표
+
+- Week 4: 5-8 MIPS
+- Week 8: 8-12 MIPS
+- Week 12: 12-20 MIPS
+- 사이클 정확 대비 50-200배 향상
+
+## 6.2 병목 및 최적화 전략
+
+- Python 오버헤드: NumPy/Numba
+- 함수 호출: 인라인, 배치
+- 딕셔너리 접근: 배열 룩업
+- asyncio 이벤트: 배칭, 경량 코루틴
+- 메모리: 객체 풀링, 선할당
+
+## 6.3 실제 성능 예측
+
+- **기본 ALU 루프**
+    - Lev0: 18-22 MIPS
+    - Lev1 혼합 : 15-18 MIPS
+    - 복합 워크로드: 12-15 MIPS
+- **NPU 포함 워크로드**
+    - 행렬 곱셈 64x64: 8-12 MIPS
+    - CNN 레이어 : 6-10 MIPS
+    - 복합 AI: 5-8 MIPS
+- **최적화 적용**
+    - NumPy: +50~100%
+    - Numba: +200~500%
+    - 메모리: +20~30%
+    - 전체통합: 15~25 MIPS
+
+---
+
+## 7. 테스트 전략
+
+## 7.1 실시간 테스트
+
+- 단위: 70%
+- 통합: 20%
+- 성능: 10%
+- pytest-benchmark 매일 성능 체크
+- 회귀 탐지 자동 알림
+
+## 7.2 주간 벤치마크 예시
+
+`pythonbenchmark_basic_ops = [
+    ("add_100k_operations", 100000, ">= 8 MIPS"),
+    ("memory_access_pattern", 50000, ">= 6 MIPS"),
+    ("branch_prediction_accuracy", 25000, ">= 5 MIPS")
+]
+benchmark_npu_ops = [
+    ("matrix_multiply_64x64", 1000, ">= 10 MIPS"),
+    ("vector_add_1k_elements", 5000, ">= 12 MIPS"),
+    ("lev0_lev1_transition_overhead", 10000, "< 15% overhead")
+]
+benchmark_complete_system = [
+    ("simple_cnn_layer", 100, ">= 8 MIPS"),
+    ("end_to_end_accuracy", 1000, "±15% error"),
+    ("memory_efficiency", 10000, "< 4GB usage")
+]`
+
+---
+
+## 8. 성공 기준 및 마일스톤
+
+| **주차** | **핵심 기능** | **성능 목표** | **검증 방법** |
+| --- | --- | --- | --- |
+| Week 2 | 기본 ALU 연산 | 5+ MIPS | 단순 루프 벤치마크 |
+| Week 4 | RISC-V 완성 | 8+ MIPS | riscv-tests 통과 |
+| Week 6 | 적응형 제어 | 10+ MIPS | Lev0↔Lev1 검증 |
+| Week 8 | NPU 연동 | 12+ MIPS | 행렬 곱셈 정확성 |
+| Week 10 | 시스템 통합 | 15+ MIPS | 복합 워크로드 테스트 |
+| Week 12 | 최종 완성 | 18+ MIPS | 전체 성능 목표 |
+- **필수 달성 목표**:
+    - 시뮬레이션 속도 12+ MIPS
+    - 50배↑ 사이클 정확 대비
+    - ±20% 정확도
+    - 안정성: 1시간 연속 실행
+- **선택 달성 목표**:
+    - 20+ MIPS
+    - 100배↑
+    - ±15%
+    - 4GB 이하 메모리
+
+---
+
+## 9. 위험 관리
+
+| **위험 요소** | **확률** | **영향** | **완화 전략** |
+| --- | --- | --- | --- |
+| Python 성능 한계 | 높음 | 중간 | NumPy/Numba, C 확장 고려 |
+| asyncio 복잡성 | 중간 | 높음 | 단순 이벤트·점진적 구현 |
+| 메모리 과다 사용 | 중간 | 중간 | 링버퍼, 객체 풀링 |
+| 정확도 미달성 | 낮음 | 높음 | 지속 검증, 적응형 보정 |
+- 일정 관리: 매주 검토, 기능 우선순위 동적조정
+- 품질 보장: pytest-watch, CI/CD, 성능 회귀 자동 탐지
+
+---
+
+## 10. 확장 계획
+
+## 10.1 Post-MVP (3개월 추가)
+
+- Lev2, Lev3 충실도
+- 멀티코어 NPU(4-16)
+- 베이지안 ROI 자동 탐지
+- 고급 LLM(Transformer 등)
+- 3각 검증
+
+## 10.2 Long-term(1년)
+
+- GUI 추가
+- 클라우드 지원
+- 50+ MIPS 최적화
+- 하드웨어가속(CUDA/OpenCL)
+- Full RISC-V ISA(RV64GCVH) 지원
+
+---
+
+## 11. 결론
+
+- **타이밍 훅 + 이벤트 기반** 하이브리드
+- **적응형 Lev0/Lev1** 충실도
+- **실시간 협업 개발**
+- **점진적 최적화**
+- **실용성 + 확장성**
+- **최대 성능 목표**: 12-20 MIPS, 사이클 정확 대비 50-200배
+- **바이브코딩 성과**: 3배 개발 속도, 품질 보증
+
+**버전**: 1.0
+
+**작성일**: 2025-09-13
+
+**개발 기간**: 3개월 (바이브코딩)
+
+**대상**: MVP (Minimum Viable Product)
+
+## 1. 프로젝트 개요
+
+### 1.1 프로젝트 목적
+
+- IA 기반 RISC-V+NPU 하이브리드 시뮬레이터 핵심 기능을 실시간 협업 개발로 3개월 MVP 완성
+- 기존 사이클 정확 시뮬레이터의 속도 한계 극복
+
+### 1.2 바이브코딩 접근법
+
+- **실시간 협업**: 즉시 피드백
+- **점진적 구현**: 매일 실행 버전
+- **지속적 검증**: 동시 테스트
+- **빠른 반복**: 주간 기능 완성
+
+### 1.3 비즈니스 목표
+
+- **검증 가능 프로토타입**
+- **성능 향상**: 기존 대비 50-200배
+- **시뮬레이션 속도**: 10-20 MIPS
+- **기본 정확도**: ±15% 이내
+- **확장성**: 고도화 가능
+
+## 2. 시스템 아키텍처
+
+### 2.1 전체 구조
+
+---
+
+## 1. 프로젝트 개요
+
+## 1.1 프로젝트 목적
+
+- IA 기반 RISC-V+NPU 하이브리드 시뮬레이터 핵심 기능을 실시간 협업 개발로 3개월 MVP 완성
+- 기존 사이클 정확 시뮬레이터의 속도 한계 극복
+
+## 1.2 바이브코딩 접근법
+
+- **실시간 협업**: 즉시 피드백
+- **점진적 구현**: 매일 실행 버전
+- **지속적 검증**: 동시 테스트
+- **빠른 반복**: 주간 기능 완성
+
+## 1.3 비즈니스 목표
+
+- **검증 가능 프로토타입**
+- **성능 향상**: 기존 대비 50-200배
+- **시뮬레이션 속도**: 10-20 MIPS
+- **기본 정확도**: ±15% 이내
+- **확장성**: 고도화 가능
+
+---
+
+## 2. 시스템 아키텍처
+
+## 2.1 전체 구조
+
+`text┌───────────────┐
+│ CLI & Config  │
+│ Manager, Loader, Results │
+└──────────────────────────
+      ▼
+┌──────────────────────────┐
+│ Adaptive Simulator Core  │
+│ RISC-V IA, Events, Adaptive Controller │
+│ Fidelity Control (Lev0↔Lev1), Timing Hook Aggregator, Event Manager (asyncio) │
+└──────────────────────────┘
+      ▼
+┌──────────────────────────┐
+│ Hardware Models          │
+│ NPU Model, Memory System │
+│ Bus/Interconnect         │
+└──────────────────────────┘`
+
+## 2.2 RISC-V IA와 이벤트 연동
+
+`textPC = 0x1000
+▼
+FETCH ─► fetch_hook(pc, inst)         # I-cache 체크, latency log  
+▼
+DECODE ─► decode_hook(inst)           # complexity 분석
+▼
+EXECUTE ─► execute_hook(op)           # Lev0/Lev1 선택, 이벤트 트리거
+▼
+PC = PC + 4
+▼
+latency_predict()                     # Table lookup/hook or async sim`
+
+## 2.3 적응형 충실도 흐름
+
+`textInstruction Ready
+▼
+Complexity Analysis
+▼
+Uncertainty > Threshold? ─► No ─► LEV0 (Hook Path) ~10-20 MIPS  
+               │
+              Yes
+               ▼
+           ROI Detected? ─► No ─► continue  
+               │
+              Yes
+               ▼
+           LEV1 (Event Path) ~3-8 MIPS  
+               ▼
+           Update Hook Coefficients
+               ▼
+           Continue Next Instruction`
+
+---
+
+## 3. 기능 요구사항 (최적화 바이브코딩)
+
+## 3.1 핵심 기능 요구사항 (MVP)
+
+## 3.1.1 RISC-V IA 엔진 (필수)
+
+- **RV64I 명령어 구현 주간별 우선순위**
+    - Week 1-2: 기본 ALU (ADD, SUB, AND, OR, XOR)
+    - Week 3-4: 메모리 접근 (LD, SD, LW, SW)
+    - Week 5-6: 분기 명령 (BEQ, BNE, JAL, JALR)
+    - Week 7-8: 곱셈/나눗셈 (MUL, DIV)
+
+## 3.1.2 2레벨 적응형 모델 (핵심)
+
+- **충실도 레벨**
+    - Lev0(Fast): 타이밍 훅 및 테이블(80%, 15-20 MIPS)
+    - Lev1(Accurate): 이벤트 기반 분석(20%, 3-8 MIPS)
+
+## 3.1.3 기본 NPU 모델링 (필수)
+
+- **단계별 구현**
+    - Week 1-3: 단일코어 GEMM
+    - Week 4-6: 벡터 유닛
+    - Week 7-9: 로컬 메모리 모델(SPM)
+    - Week 10-12: MMIO 인터페이스
+
+---
+
+## 3.2 Timing Hook vs Event System
+
+## 3.2.1 타이밍 훅 시스템 (Lev0)
+
+`pythonclass TimingHookSystem:
+    def __init__(self):
+        self.hook_stats = {
+            'fetch': RingBuffer(1000),
+            'decode': RingBuffer(1000),
+            'execute': RingBuffer(1000),
+            'memory': RingBuffer(1000)
+        }
+
+    def fetch_hook(self, pc, inst_bits):
+        timestamp = time.time()
+        cache_miss = self._check_icache_miss(pc)
+        latency = 1 if not cache_miss else 10
+        self.hook_stats['fetch'].append({
+            'timestamp': timestamp,
+            'latency': latency,
+            'cache_miss': cache_miss
+        })
+        return latency
+
+    def predict_latency_lev0(self, operation):
+        *# Lev0 예측: 테이블 기반* 
+        base_latency = self.lookup_table[operation.opcode]
+        queue_penalty = self._calculate_queue_penalty()
+        conflict_adj = self._calculate_conflict_adjustment()
+        return base_latency + queue_penalty + conflict_adj`
+
+## 3.2.2 이벤트 기반 시스템 (Lev1)
+
+`pythonimport asyncio
+
+class EventBasedSystem:
+    def __init__(self):
+        self.bus_arbiter = BusArbiter()
+        self.dram_controller = DRAMController()
+        self.npu_engines = [NPUEngine(i) for i in range(4)]
+
+    async def predict_latency_lev1(self, operation):
+        await self.bus_arbiter.acquire()
+        bus_latency = await self.simulate_bus_transfer(operation)
+        if operation.needs_dram:
+            dram_latency = await self.dram_controller.access(operation.address)
+        else:
+            dram_latency = 0
+        if operation.is_npu_op:
+            npu_latency = await self._schedule_npu_execution(operation)
+        else:
+            npu_latency = 0
+        self.bus_arbiter.release()
+        return bus_latency + dram_latency + npu_latency`
+
+---
+
+## 3.3 성능 요구사항 및 예측
+
+| **메트릭** | **Week 4 목표** | **Week 8 목표** | **Week 12 목표** |
+| --- | --- | --- | --- |
+| 시뮬레이션 속도 | 5-8 MIPS | 8-12 MIPS | 12-20 MIPS |
+| Cycle 대비 속도 | 20배 | 50배 | 100배 |
+| 정확도 | ±25% | ±20% | ±15% |
+| 메모리 사용량 | 6GB | 5GB | 4GB |
+| 코드 커버리지 | 50% | 65% | 70% |
+
+---
+
+## 4. 바이브코딩 개발 로드맵 (12주)
+
+## Phase 1: 기반 엔진 (1-4주)
+
+- Week 1: 프로젝트 세팅, 기본 IA 엔진, 타이밍 훅, 고정테이블 구현
+- Week 2: ALU + 훅 통계, 단위/통합 테스트
+- Week 3: 메모리 접근 및 훅
+- Week 4: 분기명령, 성능 측정
+
+## Phase 2: NPU + 이벤트 시스템 (5-8주)
+
+- Week 5: NPU 모델, MMIO, asyncio 구성
+- Week 6: 레벨 전환, 분류기, 적응형 테스트
+- Week 7: 벡터연산, SPM/버스 모델
+- Week 8: 최적화, 벡터화, 병목 프로파일링
+
+## Phase 3: 통합 및 검증 (9-12주)
+
+- Week 9: 시스템 통합, 워크로드 테스트
+- Week 10: 메모리 최적화, ROI
+- Week 11: 다양한 워크로드, 정확도·속도 분석
+- Week 12: 문서, API, 최종 벤치마킹
+
+---
+
+## 5. 기술 스펙 및 상세 구현
+
+## 5.1 개발 환경 및 도구
+
+- VS Code Live Share
+- Discord/Slack
+- GitHub + CI/CD
+- pytest-watch
+- cProfile, memory_profiler, pytest-benchmark, line_profiler
+
+## 5.2 핵심 클래스 예시
+
+## AdaptiveSimulator
+
+`pythonclass AdaptiveSimulator:
+    def __init__(self, config_path: str):
+        self.risc_v_engine = RISCVEngine()
+        self.timing_hooks = TimingHookSystem()
+        self.event_system = EventBasedSystem()
+        self.fidelity_controller = FidelityController()
+    def run_simulation(self) -> SimulationResult:
+        while not self.halt:
+            inst_result = self.risc_v_engine.execute_instruction()
+            if self.fidelity_controller.should_use_lev1(inst_result):
+                latency = await self.event_system.predict_latency_lev1(inst_result)
+            else:
+                latency = self.timing_hooks.predict_latency_lev0(inst_result)
+            self.sim_time += latency
+        return SimulationResult(...)`
+
+## RISCVEngine
+
+`pythonclass RISCVEngine:
+    def __init__(self):
+        self.decoder = RISCVDecoder()
+        self.state = ProcessorState()
+        self.complexity_classifier = ComplexityClassifier()
+    def execute_instruction(self) -> InstructionResult:
+        inst_bits = self.fetch(self.state.pc)
+        fetch_latency = self.timing_hooks.fetch_hook(self.state.pc, inst_bits)
+        decoded = self.decoder.decode(inst_bits)
+        decode_latency = self.timing_hooks.decode_hook(decoded)
+        result = self._execute_functional(decoded)
+        execute_latency = self.timing_hooks.execute_hook(decoded, result)
+        self._commit_state(result)
+        return InstructionResult(
+            instruction=decoded,
+            result=result,
+            complexity=self.complexity_classifier.classify(decoded),
+            base_latency=fetch_latency + decode_latency + execute_latency
+        )`
+
+---
+
+## 6. 시뮬레이션 성능 및 최적화
+
+## 6.1 기준점 비교
+
+기존 시뮬레이터
+
+- gem5(사이클 정확): 0.01-0.3 MIPS
+- SESC: ~0.02 MIPS
+- QEMU: 50-200+ MIPS
+- RISC-V Virtual Prototype: 27-32 MIPS
+- 컴파일드 시뮬레이터: ~10 MIPS
+
+목표
+
+- Week 4: 5-8 MIPS
+- Week 8: 8-12 MIPS
+- Week 12: 12-20 MIPS
+- 사이클 정확 대비 50-200배 향상
+
+## 6.2 병목 및 최적화 전략
+
+- Python 오버헤드: NumPy/Numba
+- 함수 호출: 인라인, 배치
+- 딕셔너리 접근: 배열 룩업
+- asyncio 이벤트: 배칭, 경량 코루틴
+- 메모리: 객체 풀링, 선할당
+
+## 6.3 실제 성능 예측
+
+- **기본 ALU 루프**
+    - Lev0: 18-22 MIPS
+    - Lev1 혼합 : 15-18 MIPS
+    - 복합 워크로드: 12-15 MIPS
+- **NPU 포함 워크로드**
+    - 행렬 곱셈 64x64: 8-12 MIPS
+    - CNN 레이어 : 6-10 MIPS
+    - 복합 AI: 5-8 MIPS
+- **최적화 적용**
+    - NumPy: +50~100%
+    - Numba: +200~500%
+    - 메모리: +20~30%
+    - 전체통합: 15~25 MIPS
+
+---
+
+## 7. 테스트 전략
+
+## 7.1 실시간 테스트
+
+- 단위: 70%
+- 통합: 20%
+- 성능: 10%
+- pytest-benchmark 매일 성능 체크
+- 회귀 탐지 자동 알림
+
+## 7.2 주간 벤치마크 예시
+
+`pythonbenchmark_basic_ops = [
+    ("add_100k_operations", 100000, ">= 8 MIPS"),
+    ("memory_access_pattern", 50000, ">= 6 MIPS"),
+    ("branch_prediction_accuracy", 25000, ">= 5 MIPS")
+]
+benchmark_npu_ops = [
+    ("matrix_multiply_64x64", 1000, ">= 10 MIPS"),
+    ("vector_add_1k_elements", 5000, ">= 12 MIPS"),
+    ("lev0_lev1_transition_overhead", 10000, "< 15% overhead")
+]
+benchmark_complete_system = [
+    ("simple_cnn_layer", 100, ">= 8 MIPS"),
+    ("end_to_end_accuracy", 1000, "±15% error"),
+    ("memory_efficiency", 10000, "< 4GB usage")
+]`
+
+---
+
+## 8. 성공 기준 및 마일스톤
+
+| **주차** | **핵심 기능** | **성능 목표** | **검증 방법** |
+| --- | --- | --- | --- |
+| Week 2 | 기본 ALU 연산 | 5+ MIPS | 단순 루프 벤치마크 |
+| Week 4 | RISC-V 완성 | 8+ MIPS | riscv-tests 통과 |
+| Week 6 | 적응형 제어 | 10+ MIPS | Lev0↔Lev1 검증 |
+| Week 8 | NPU 연동 | 12+ MIPS | 행렬 곱셈 정확성 |
+| Week 10 | 시스템 통합 | 15+ MIPS | 복합 워크로드 테스트 |
+| Week 12 | 최종 완성 | 18+ MIPS | 전체 성능 목표 |
+- **필수 달성 목표**:
+    - 시뮬레이션 속도 12+ MIPS
+    - 50배↑ 사이클 정확 대비
+    - ±20% 정확도
+    - 안정성: 1시간 연속 실행
+- **선택 달성 목표**:
+    - 20+ MIPS
+    - 100배↑
+    - ±15%
+    - 4GB 이하 메모리
+
+---
+
+## 9. 위험 관리
+
+| **위험 요소** | **확률** | **영향** | **완화 전략** |
+| --- | --- | --- | --- |
+| Python 성능 한계 | 높음 | 중간 | NumPy/Numba, C 확장 고려 |
+| asyncio 복잡성 | 중간 | 높음 | 단순 이벤트·점진적 구현 |
+| 메모리 과다 사용 | 중간 | 중간 | 링버퍼, 객체 풀링 |
+| 정확도 미달성 | 낮음 | 높음 | 지속 검증, 적응형 보정 |
+- 일정 관리: 매주 검토, 기능 우선순위 동적조정
+- 품질 보장: pytest-watch, CI/CD, 성능 회귀 자동 탐지
+
+---
+
+## 10. 확장 계획
+
+## 10.1 Post-MVP (3개월 추가)
+
+- Lev2, Lev3 충실도
+- 멀티코어 NPU(4-16)
+- 베이지안 ROI 자동 탐지
+- 고급 LLM(Transformer 등)
+- 3각 검증
+
+## 10.2 Long-term(1년)
+
+- GUI 추가
+- 클라우드 지원
+- 50+ MIPS 최적화
+- 하드웨어가속(CUDA/OpenCL)
+- Full RISC-V ISA(RV64GCVH) 지원
+
+---
+
+## 11. 결론
+
+- **타이밍 훅 + 이벤트 기반** 하이브리드
+- **적응형 Lev0/Lev1** 충실도
+- **실시간 협업 개발**
+- **점진적 최적화**
+- **실용성 + 확장성**
+- **최대 성능 목표**: 12-20 MIPS, 사이클 정확 대비 50-200배
+- **바이브코딩 성과**: 3배 개발 속도, 품질 보증

--- a/ia_risc_v_npu/requirements.txt
+++ b/ia_risc_v_npu/requirements.txt
@@ -1,2 +1,3 @@
+pyelftools
 pytest
 pytest-asyncio

--- a/ia_risc_v_npu/specs/001-ia-risc-v/tasks.md
+++ b/ia_risc_v_npu/specs/001-ia-risc-v/tasks.md
@@ -72,7 +72,7 @@
   - [x] Parametrize the CNN workload test to run with a variety of configurations.
   - [x] Add result verification to the CNN workload test.
   - [x] Add a test for a 2-layer CNN workload.
-- [ ] T032: Analyze the accuracy and performance of the simulator against the goals in `prd.md`.
+- [x] T032: Analyze the accuracy and performance of the simulator against the goals in `prd.md`.
 
 ### Week 12: Finalization
 - [ ] T033: [P] Create final documentation for the simulator.

--- a/ia_risc_v_npu/specs/001-ia-risc-v/tasks.md
+++ b/ia_risc_v_npu/specs/001-ia-risc-v/tasks.md
@@ -73,10 +73,13 @@
   - [x] Add result verification to the CNN workload test.
   - [x] Add a test for a 2-layer CNN workload.
 - [x] T032: Analyze the accuracy and performance of the simulator against the goals in `prd.md`.
+  - [x] Added CLI benchmark command to record elapsed seconds and compute MIPS for goal tracking.
 
 ### Week 12: Finalization
 - [ ] T033: [P] Create final documentation for the simulator.
-- [ ] T034: [P] Implement the CLI using the contract in `contracts/cli.md`.
+- [x] T034: [P] Implement the CLI using the contract in `contracts/cli.md`.
+  - [x] Added `simulate` command that loads ELF binaries, optional JSON 설정, 결과 요약 출력.
+  - [x] 시뮬레이터 입력/출력 정리 및 로깅 기반 상태 보고.
 - [ ] T035: [P] Run final benchmarks and generate a performance report.
 - [x] T036: [P] Reorganize project documentation structure.
 - [x] T037: [P] Create a comprehensive README.md file.

--- a/ia_risc_v_npu/src/risc_v/engine.py
+++ b/ia_risc_v_npu/src/risc_v/engine.py
@@ -1,10 +1,11 @@
-from src.risc_v.instructions import alu
-from src.risc_v.instructions import memory
+from src.risc_v.instructions import alu, memory, control_flow
+import numpy as np
 
 # Instruction format constants
 OPCODE_R_TYPE = 0b0110011
 OPCODE_I_TYPE_LOAD = 0b0000011
 OPCODE_S_TYPE_STORE = 0b0100011
+OPCODE_B_TYPE = 0b1100011
 OPCODE_R4_TYPE_FMADD = 0b1000011
 OPCODE_J_TYPE_JAL = 0b1101111
 
@@ -28,6 +29,7 @@ class RISCVEngine:
         self.pc = 0
         self.registers = [0] * 32
         self.bus = bus
+        self.instruction_count = 0
 
         # Initialize registers for testing
         self.registers[2] = 10
@@ -76,10 +78,7 @@ class RISCVEngine:
         rs3 = (instruction >> 27) & 0x1F
         return opcode, rd, funct3, rs1, rs2, rs3
 
-    def _decode_j_type_instruction(self, instruction):
-        opcode = instruction & 0x7F
-        rd = (instruction >> 7) & 0x1F
-
+    def _decode_j_type_instruction(self, instruction: int) -> tuple[int, int, int]:
         imm_20 = (instruction >> 31) & 0x1
         imm_10_1 = (instruction >> 21) & 0x3FF
         imm_11 = (instruction >> 20) & 0x1
@@ -87,11 +86,27 @@ class RISCVEngine:
 
         imm = (imm_20 << 20) | (imm_19_12 << 12) | (imm_11 << 11) | (imm_10_1 << 1)
 
-        # Sign extend from 21 bits
-        if (imm >> 20) & 1:
-            imm |= ~((1 << 21) - 1)
+        # Sign-extend the 21-bit immediate to 32 bits
+        if imm & (1 << 20):
+            imm -= (1 << 21)
+
+        rd = (instruction >> 7) & 0x1F
+        opcode = instruction & 0x7F
 
         return opcode, rd, imm
+
+    def _decode_b_type_instruction(self, instruction):
+        opcode = instruction & 0x7F
+        imm1 = (instruction >> 7) & 0x1F
+        funct3 = (instruction >> 12) & 0x7
+        rs1 = (instruction >> 15) & 0x1F
+        rs2 = (instruction >> 20) & 0x1F
+        imm2 = (instruction >> 25) & 0x7F
+        imm = ((imm2 & 0x40) << 6) | ((imm1 & 1) << 11) | ((imm2 & 0x3F) << 5) | ((imm1 & 0x1E) >> 1)
+        if (imm >> 12) & 1:
+            imm -= 1 << 13
+        print(f"DECODE B-TYPE: opcode={opcode}, funct3={funct3}, rs1={rs1}, rs2={rs2}, imm={imm}")
+        return opcode, funct3, rs1, rs2, imm
 
     def _execute_alu_instruction(self, funct3, rd, rs1, rs2, funct7):
         if rd == 0: # x0 is hardwired to zero, so no-op
@@ -139,19 +154,44 @@ class RISCVEngine:
         else:
             raise ValueError(f"Unsupported FMADD instruction: funct3={funct3}")
 
-    def _execute_jal_instruction(self, rd, imm):
+    def _execute_jal_instruction(self, rd, imm, original_pc):
         if rd != 0:
-            self.registers[rd] = self.pc + 4
-        self.pc += imm
+            self.registers[rd] = original_pc + 4
+        self.pc = original_pc + imm
+
+    def _execute_branch_instruction(self, funct3, rs1, rs2, imm, original_pc):
+        val1 = self.registers[rs1]
+        val2 = self.registers[rs2]
+        
+        branch_taken = False
+        if funct3 == 0b000: # BEQ
+            branch_taken = control_flow.beq(val1, val2)
+        elif funct3 == 0b001: # BNE
+            branch_taken = control_flow.bne(val1, val2)
+        elif funct3 == 0b100: # BLT
+            branch_taken = control_flow.blt(val1, val2)
+        elif funct3 == 0b101: # BGE
+            branch_taken = control_flow.bge(val1, val2)
+        elif funct3 == 0b110: # BLTU
+            branch_taken = control_flow.bltu(val1, val2)
+        elif funct3 == 0b111: # BGEU
+            branch_taken = control_flow.bgeu(val1, val2)
+
+        if branch_taken:
+            self.pc = original_pc + imm
+            print(f"BRANCH from {original_pc:08x} to {self.pc:08x}")
 
     def execute_instruction(self):
+        self.instruction_count += 1
         instruction = self._read_word(self.pc)
+        print(f"PC: {self.pc:08x}, Instruction: {instruction:08x}")
         original_pc = self.pc
         opcode = instruction & 0x7F
 
         if instruction == 0:
             return "halt"
 
+        pc_changed = False
         if opcode == OPCODE_R_TYPE:
             _, rd, funct3, rs1, rs2, funct7 = self._decode_r_type_instruction(instruction)
             self._execute_alu_instruction(funct3, rd, rs1, rs2, funct7)
@@ -161,6 +201,11 @@ class RISCVEngine:
         elif opcode == OPCODE_S_TYPE_STORE:
             _, funct3, rs1, rs2, imm = self._decode_s_type_instruction(instruction)
             self._execute_store_instruction(funct3, rs1, rs2, imm)
+        elif opcode == OPCODE_B_TYPE:
+            _, funct3, rs1, rs2, imm = self._decode_b_type_instruction(instruction)
+            self._execute_branch_instruction(funct3, rs1, rs2, imm, original_pc)
+            if self.pc != original_pc: # if branch was taken
+                pc_changed = True
         elif opcode == OPCODE_R4_TYPE_FMADD:
             _, rd, funct3, rs1, rs2, rs3 = self._decode_r4_type_instruction(instruction)
             self._execute_fmadd_instruction(funct3, rd, rs1, rs2, rs3)
@@ -168,12 +213,13 @@ class RISCVEngine:
             _, rd, imm = self._decode_j_type_instruction(instruction)
             if rd == 0 and imm == 0:
                 return "halt"
-            self._execute_jal_instruction(rd, imm)
+            self._execute_jal_instruction(rd, imm, original_pc)
+            print(f"JUMP from {original_pc:08x} to {self.pc:08x}")
+            pc_changed = True
         else:
             raise ValueError(f"Unsupported opcode: {opcode}")
         
-        # If the PC was not changed by a jump/branch instruction, increment it by 4
-        if self.pc == original_pc:
+        if not pc_changed:
             self.pc += 4
         
         return "continue"

--- a/ia_risc_v_npu/src/risc_v/instructions/control_flow.py
+++ b/ia_risc_v_npu/src/risc_v/instructions/control_flow.py
@@ -1,12 +1,28 @@
-def beq(state, rs1, rs2, imm):
-    if rs1 == rs2:
-        return state.pc + imm
-    return state.pc + 4
+import numpy as np
 
-def bne(state, rs1, rs2, imm):
-    if rs1 != rs2:
-        return state.pc + imm
-    return state.pc + 4
+def beq(rs1, rs2):
+    """Branch if equal."""
+    return rs1 == rs2
+
+def bne(rs1, rs2):
+    """Branch if not equal."""
+    return rs1 != rs2
+
+def blt(rs1, rs2):
+    """Branch if less than (signed)."""
+    return np.int32(rs1) < np.int32(rs2)
+
+def bge(rs1, rs2):
+    """Branch if greater than or equal (signed)."""
+    return np.int32(rs1) >= np.int32(rs2)
+
+def bltu(rs1, rs2):
+    """Branch if less than (unsigned)."""
+    return rs1 < rs2
+
+def bgeu(rs1, rs2):
+    """Branch if greater than or equal (unsigned)."""
+    return rs1 >= rs2
 
 def jal(state, imm):
     state.pc = state.pc + 4

--- a/ia_risc_v_npu/src/risc_v/instructions/memory.py
+++ b/ia_risc_v_npu/src/risc_v/instructions/memory.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 def ld(bus, address):
     return int.from_bytes(bus.read(address, 8), 'little')
 
@@ -8,4 +10,7 @@ def lw(bus, address):
     return int.from_bytes(bus.read(address, 4), 'little')
 
 def sw(bus, address, value):
-    bus.write(address, value.to_bytes(4, 'little'))
+    if isinstance(value, np.uint32):
+        bus.write(address, value.tobytes())
+    else:
+        bus.write(address, value.to_bytes(4, 'little'))

--- a/ia_risc_v_npu/src/simulator/cli.py
+++ b/ia_risc_v_npu/src/simulator/cli.py
@@ -1,0 +1,285 @@
+"""Command-line interface for the IA RISC-V + NPU simulator."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter
+from typing import Iterable, List, Optional
+
+try:  # pragma: no cover - import guarded for environments without pyelftools
+    from elftools.elf.elffile import ELFFile
+except ImportError:  # pragma: no cover - fallback handled at runtime
+    ELFFile = None  # type: ignore[assignment]
+
+from src.simulator.main import AdaptiveSimulator, SimulationResult, DRAM_SIZE
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CLIError(RuntimeError):
+    """Raised when the CLI cannot complete the requested action."""
+
+
+@dataclass(slots=True)
+class ProgramImage:
+    instructions: List[int]
+    text_size: int
+
+
+@dataclass(slots=True)
+class BenchmarkMetrics:
+    elapsed_seconds: float
+    instructions_executed: int
+    mips: float
+
+
+def configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s %(name)s: %(message)s")
+
+
+def load_config(config_path: Optional[Path]) -> dict:
+    if not config_path:
+        return {}
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError as exc:
+        raise CLIError(f"Config file not found: {config_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise CLIError(f"Config file is not valid JSON: {config_path}") from exc
+
+    if not isinstance(data, dict):
+        raise CLIError("Config file must contain a JSON object")
+    return data
+
+
+def _extract_instruction_words(data: bytes) -> List[int]:
+    if len(data) % 4 != 0:
+        raise CLIError("Executable section size must be word-aligned (4 bytes)")
+    words = [int.from_bytes(data[i : i + 4], "little", signed=False) for i in range(0, len(data), 4)]
+    return words
+
+
+def load_program_image(elf_path: Path) -> ProgramImage:
+    if ELFFile is None:
+        raise CLIError("pyelftools is required to load ELF binaries. Install it via 'pip install pyelftools'.")
+    try:
+        with elf_path.open("rb") as handle:
+            elf = ELFFile(handle)
+            exec_sections: List[tuple[int, bytes]] = []
+
+            text_section = elf.get_section_by_name(".text")
+            if text_section and text_section.data():
+                exec_sections.append((text_section["sh_addr"], text_section.data()))
+
+            if not exec_sections:
+                for section in elf.iter_sections():
+                    flags = int(section["sh_flags"])
+                    data = section.data()
+                    if flags & 0x4 and data:  # SHF_EXECINSTR
+                        exec_sections.append((section["sh_addr"], data))
+
+    except FileNotFoundError as exc:
+        raise CLIError(f"ELF file not found: {elf_path}") from exc
+    except OSError as exc:
+        raise CLIError(f"Failed to read ELF file: {elf_path}") from exc
+
+    if not exec_sections:
+        raise CLIError("ELF file does not contain executable instructions")
+
+    exec_sections.sort(key=lambda item: item[0])
+    instructions: List[int] = []
+    for _, data in exec_sections:
+        instructions.extend(_extract_instruction_words(data))
+
+    text_size = sum(len(data) for _, data in exec_sections)
+    return ProgramImage(instructions=instructions, text_size=text_size)
+
+
+def write_output(
+    result: SimulationResult,
+    output_path: Optional[Path],
+    instruction_count: int,
+    *,
+    extra: Optional[dict] = None,
+) -> None:
+    summary = {
+        "cycles": result.cycles,
+        "halted": result.halted,
+        "reason": result.reason,
+        "sim_time": result.sim_time,
+        "instructions_executed": instruction_count,
+    }
+    if extra:
+        summary.update(extra)
+    LOGGER.info(
+        "Simulation finished: cycles=%s halted=%s reason=%s", result.cycles, result.halted, result.reason
+    )
+    if output_path:
+        try:
+            with output_path.open("w", encoding="utf-8") as handle:
+                json.dump(summary, handle, indent=2)
+        except OSError as exc:
+            raise CLIError(f"Failed to write output file: {output_path}") from exc
+
+
+def run_simulate(args: argparse.Namespace) -> int:
+    configure_logging(args.verbose)
+    config = load_config(args.config)
+    max_cycles = int(config.get("max_cycles", 0) or 0)
+
+    program = load_program_image(args.elf_file)
+    simulator = AdaptiveSimulator()
+    simulator.load_program(program.instructions)
+
+    LOGGER.debug("Loaded %s bytes (%s instructions)", program.text_size, len(program.instructions))
+
+    result = asyncio.run(simulator.run_simulation(max_cycles=max_cycles))
+    write_output(result, args.output, simulator.risc_v_engine.instruction_count)
+    return 0
+
+
+def _generate_synthetic_program(length: int) -> ProgramImage:
+    if length <= 0:
+        raise CLIError("Synthetic program length must be positive")
+
+    # DRAM holds 1MB, so ensure the program fits.
+    max_words = (DRAM_SIZE // 4) - 1  # reserve space for halt instruction
+    if length > max_words:
+        raise CLIError(f"Synthetic program length exceeds DRAM capacity ({max_words} instructions)")
+
+    add_instruction = 0x003100B3  # ADD x1, x2, x3
+    program = [add_instruction] * length
+    program.append(0)  # halt sentinel
+    return ProgramImage(instructions=program, text_size=len(program) * 4)
+
+
+def _measure_performance(simulator: AdaptiveSimulator, max_cycles: int) -> tuple[SimulationResult, BenchmarkMetrics]:
+    start = perf_counter()
+    result = asyncio.run(simulator.run_simulation(max_cycles=max_cycles))
+    elapsed = perf_counter() - start
+    executed = simulator.risc_v_engine.instruction_count
+    mips = (executed / elapsed / 1_000_000) if elapsed > 0 else 0.0
+    metrics = BenchmarkMetrics(elapsed_seconds=elapsed, instructions_executed=executed, mips=mips)
+    return result, metrics
+
+
+def run_benchmark(args: argparse.Namespace) -> int:
+    configure_logging(args.verbose)
+    config = load_config(args.config)
+    max_cycles = int(config.get("max_cycles", 0) or args.max_cycles or 0)
+
+    if args.elf_file:
+        program = load_program_image(args.elf_file)
+    else:
+        program = _generate_synthetic_program(args.instructions)
+
+    simulator = AdaptiveSimulator()
+    simulator.load_program(program.instructions)
+
+    LOGGER.debug(
+        "Benchmark program loaded: %s instructions (%s bytes)",
+        len(program.instructions),
+        program.text_size,
+    )
+
+    result, metrics = _measure_performance(simulator, max_cycles)
+
+    LOGGER.info(
+        "Benchmark completed: elapsed=%.4fs, instructions=%s, MIPS=%.2f",
+        metrics.elapsed_seconds,
+        metrics.instructions_executed,
+        metrics.mips,
+    )
+
+    write_output(
+        result,
+        args.output,
+        simulator.risc_v_engine.instruction_count,
+        extra={
+            "elapsed_seconds": metrics.elapsed_seconds,
+            "mips": metrics.mips,
+        },
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="IA RISC-V + NPU Simulator CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    simulate_parser = subparsers.add_parser("simulate", help="run a simulation from an ELF binary")
+    simulate_parser.add_argument("elf_file", type=Path, help="Path to the RISC-V ELF binary")
+    simulate_parser.add_argument(
+        "--config", type=Path, default=None, help="Path to a JSON config file with simulation options"
+    )
+    simulate_parser.add_argument(
+        "--output", type=Path, default=None, help="Write simulation summary to the specified path"
+    )
+    simulate_parser.add_argument("--verbose", action="store_true", help="Enable verbose logging output")
+    simulate_parser.set_defaults(handler=run_simulate)
+
+    benchmark_parser = subparsers.add_parser(
+        "benchmark", help="measure wall-clock performance and report MIPS"
+    )
+    benchmark_parser.add_argument(
+        "--elf-file",
+        type=Path,
+        default=None,
+        help="Optional path to a RISC-V ELF binary to benchmark",
+    )
+    benchmark_parser.add_argument(
+        "--instructions",
+        type=int,
+        default=200_000,
+        help="Synthetic ADD instruction count when no ELF is provided",
+    )
+    benchmark_parser.add_argument(
+        "--max-cycles",
+        type=int,
+        default=0,
+        help="Optional cycle cap for the benchmark run",
+    )
+    benchmark_parser.add_argument(
+        "--config", type=Path, default=None, help="Path to a JSON config file with simulation options"
+    )
+    benchmark_parser.add_argument(
+        "--output", type=Path, default=None, help="Write benchmark summary to the specified path"
+    )
+    benchmark_parser.add_argument("--verbose", action="store_true", help="Enable verbose logging output")
+    benchmark_parser.set_defaults(handler=run_benchmark)
+
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if not hasattr(args, "handler"):
+        parser.print_help()
+        return 1
+
+    try:
+        return args.handler(args)
+    except CLIError as exc:
+        LOGGER.error("%s", exc)
+        return 1
+
+
+__all__ = [
+    "main",
+    "load_program_image",
+    "load_config",
+    "CLIError",
+    "BenchmarkMetrics",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/ia_risc_v_npu/src/simulator/memory.py
+++ b/ia_risc_v_npu/src/simulator/memory.py
@@ -1,3 +1,9 @@
+import logging
+
+
+LOGGER = logging.getLogger(__name__)
+
+
 class SPM:
     """Scratchpad Memory (SPM)"""
     def __init__(self, size_kb):
@@ -27,9 +33,15 @@ class Bus:
         }
 
     def _find_device(self, address, size):
+        LOGGER.debug("bus lookup: address=%s size=%s", address, size)
         for name, info in self.devices.items():
-            if info["start_addr"] <= address and address + size - 1 <= info["end_addr"]:
-                return info["device"], address - info["start_addr"]
+            start = info["start_addr"]
+            end = info["end_addr"]
+            LOGGER.debug("  checking %s: start=%s end=%s", name, start, end)
+            if start <= address and address + size - 1 <= end:
+                LOGGER.debug("  device %s selected", name)
+                return info["device"], address - start
+        LOGGER.debug("  no device for address=%s size=%s", address, size)
         return None, None
 
     def read(self, address, size):
@@ -44,8 +56,10 @@ class Bus:
 
     def write(self, address, data):
         device, local_addr = self._find_device(address, len(data))
-        if device:
-            if hasattr(device, 'write'):
-                device.write(local_addr, data)
-            else:
-                device[local_addr:local_addr+len(data)] = data
+        if not device:
+            raise MemoryError(f"No device found or access out of bounds for address {address} with size {len(data)}")
+
+        if hasattr(device, 'write'):
+            device.write(local_addr, data)
+        else:
+            device[local_addr:local_addr+len(data)] = data

--- a/ia_risc_v_npu/tests/integration/test_cnn_workload.py
+++ b/ia_risc_v_npu/tests/integration/test_cnn_workload.py
@@ -44,9 +44,9 @@ async def test_run_cnn_workload_with_verification(input_shape, kernel_config):
     workload.append(0x0000006F)
     # 3. Initialize the simulator and memory
     simulator = AdaptiveSimulator()
-    input_addr = 0x1000
-    weights_addr = 0x2000
-    output_addr = 0x3000
+    input_addr = 0x20000
+    weights_addr = 0x30000
+    output_addr = 0x40000
 
     simulator.risc_v_engine.registers[REG_T0] = input_addr
     simulator.risc_v_engine.registers[REG_T1] = weights_addr

--- a/ia_risc_v_npu/tests/integration/test_cnn_workload.py
+++ b/ia_risc_v_npu/tests/integration/test_cnn_workload.py
@@ -1,28 +1,36 @@
 import pytest
 import numpy as np
+import time
 from src.simulator.main import AdaptiveSimulator
-from workloads.cnn_workload import generate_cnn_workload
+from workloads.cnn_workload import generate_cnn_layer_workload
 
 # Register ABI names for clarity
-REG_T0 = 5 # input_addr_reg
-REG_T1 = 6 # weight_addr_reg
-REG_T2 = 7 # output_addr_reg
+REG_T0 = 5  # input_addr_reg
+REG_T1 = 6  # weight_addr_reg
+REG_T2 = 7  # output_addr_reg
 
-@pytest.mark.parametrize("input_shape, kernel_shape", [
-    ((1, 3, 3), (1, 2, 2)),
-    ((2, 4, 4), (2, 2, 2)),
-    ((1, 5, 5), (1, 3, 3)),
+# Parametrize with (input_shape, (out_channels, kernel_height, kernel_width))
+@pytest.mark.parametrize("input_shape, kernel_config", [
+    ((1, 3, 3), (1, 2, 2)),  # in_channels=1, out_channels=1
+    ((2, 4, 4), (3, 2, 2)),  # in_channels=2, out_channels=3
+    ((1, 5, 5), (2, 3, 3)),  # in_channels=1, out_channels=2
+    ((1, 16, 16), (1, 4, 4)), # Larger test case
 ])
 @pytest.mark.asyncio
-async def test_run_cnn_workload_with_verification(input_shape, kernel_shape):
+async def test_run_cnn_workload_with_verification(input_shape, kernel_config):
     """
-    Tests running a generated 2D CNN workload on the simulator and verifies the results.
+    Tests running a generated 2D CNN workload on the simulator, verifies the results, and measures performance.
     """
     # 1. Generate test data
-    channels, height, width = input_shape
-    _, kernel_height, kernel_width = kernel_shape
-    input_data = np.arange(1, channels * height * width + 1, dtype=np.uint32).reshape(input_shape)
-    weights = np.arange(1, channels * kernel_height * kernel_width + 1, dtype=np.uint32).reshape(kernel_shape)
+    in_channels, height, width = input_shape
+    out_channels, kernel_height, kernel_width = kernel_config
+
+    # Define full shapes
+    full_input_shape = (in_channels, height, width)
+    full_kernel_shape = (out_channels, in_channels, kernel_height, kernel_width)
+
+    input_data = np.arange(1, full_input_shape[0] * full_input_shape[1] * full_input_shape[2] + 1, dtype=np.uint32).reshape(full_input_shape)
+    weights = np.arange(1, full_kernel_shape[0] * full_kernel_shape[1] * full_kernel_shape[2] * full_kernel_shape[3] + 1, dtype=np.uint32).reshape(full_kernel_shape)
 
     # 2. Generate the CNN workload
     reg_config = {
@@ -30,10 +38,10 @@ async def test_run_cnn_workload_with_verification(input_shape, kernel_shape):
         'weight_addr': REG_T1,
         'output_addr': REG_T2,
     }
-    workload = generate_cnn_workload(input_shape, kernel_shape, reg_config)
+    workload = generate_cnn_layer_workload(full_input_shape, full_kernel_shape, reg_config)
+    print(f"Workload length: {len(workload)}")
     # Add a halt instruction (JAL x0, 0) to the end
     workload.append(0x0000006F)
-
     # 3. Initialize the simulator and memory
     simulator = AdaptiveSimulator()
     input_addr = 0x1000
@@ -50,30 +58,54 @@ async def test_run_cnn_workload_with_verification(input_shape, kernel_shape):
 
     # 4. Load and run the program
     simulator.load_program(workload)
-    # Run with a generous cycle limit, relying on the halt instruction
-    await simulator.run_simulation(max_cycles=len(workload) * 10)
 
-    # 5. Calculate expected output
+    # Reset instruction counter and start timer
+    simulator.risc_v_engine.instruction_count = 0
+    start_time = time.perf_counter()
+
+    # Run with a generous cycle limit, relying on the halt instruction
+    await simulator.run_simulation(max_cycles=len(workload) * 20) # Increased max_cycles just in case
+
+    end_time = time.perf_counter()
+
+    # 5. Calculate and report MIPS
+    execution_time = end_time - start_time
+    instructions_executed = simulator.risc_v_engine.instruction_count
+    if execution_time > 0:
+        mips = (instructions_executed / execution_time) / 1_000_000
+    else:
+        mips = float('inf')
+
+    print(f"\n--- CNN Workload Performance ---")
+    print(f"Parameters: input={full_input_shape}, kernel={full_kernel_shape}")
+    print(f"Instructions: {instructions_executed}")
+    print(f"Execution Time: {execution_time:.6f}s")
+    print(f"Performance: {mips:.2f} MIPS")
+    print(f"------------------------------------")
+
+    # 6. Calculate expected output
     output_height = height - kernel_height + 1
     output_width = width - kernel_width + 1
-    expected_output = np.zeros((output_height, output_width), dtype=np.uint32)
-    for i in range(output_height):
-        for j in range(output_width):
-            acc = 0
-            for c in range(channels):
-                for ky in range(kernel_height):
-                    for kx in range(kernel_width):
-                        input_val = input_data[c, i + ky, j + kx]
-                        weight_val = weights[c, ky, kx]
-                        acc += input_val * weight_val
-            expected_output[i, j] = acc
+    expected_output = np.zeros((out_channels, output_height, output_width), dtype=np.uint32)
+    for oc in range(out_channels):
+        for i in range(output_height):
+            for j in range(output_width):
+                acc = 0
+                for c in range(in_channels):
+                    for ky in range(kernel_height):
+                        for kx in range(kernel_width):
+                            input_val = input_data[c, i + ky, j + kx]
+                            weight_val = weights[oc, c, ky, kx]
+                            acc += input_val * weight_val
+                expected_output[oc, i, j] = acc
 
-    # 6. Read output from memory and verify
+    # 7. Read output from memory and verify
     output_size_bytes = expected_output.nbytes
     result_bytes = simulator.bus.read(output_addr, output_size_bytes)
     result = np.frombuffer(result_bytes, dtype=np.uint32).reshape(expected_output.shape)
     np.testing.assert_array_equal(result, expected_output)
 
     # Also check the PC to ensure it halted at the last instruction
-    expected_pc = len(workload) * 4 - 4
+    # The workload generator produces a list of instructions, so the address of the last instruction is (len(workload) - 1) * 4
+    expected_pc = (len(workload) - 1) * 4
     assert simulator.risc_v_engine.pc == expected_pc

--- a/ia_risc_v_npu/tests/performance/test_performance.py
+++ b/ia_risc_v_npu/tests/performance/test_performance.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from src.risc_v.instructions import alu, control_flow, memory
+from src.simulator.memory import SPM
 from src.npu.model import NPU
 
 # Mock state for control flow instructions
@@ -27,7 +28,11 @@ def test_xor_benchmark(benchmark):
 # T026b: Memory access instruction benchmarks
 @pytest.fixture
 def mem():
-    return bytearray(1024)
+    spm = memory.SPM(size_kb=1) # 1KB memory
+    # Initialize with some data for reads
+    for i in range(0, 1024, 4):
+        spm.write(i, (i // 4).to_bytes(4, 'little'))
+    return spm
 
 def test_ld_benchmark(benchmark, mem):
     benchmark(memory.ld, mem, 0)
@@ -44,13 +49,14 @@ def test_sw_benchmark(benchmark, mem):
 # T026c: Control flow instruction benchmarks
 @pytest.fixture
 def state():
+    # MockState is no longer needed for beq/bne, but kept for jal/jalr if they are benchmarked later
     return MockState(pc=100)
 
 def test_beq_benchmark(benchmark, state):
-    benchmark(control_flow.beq, state, 1, 1, 20)
+    benchmark(control_flow.beq, 1, 1)
 
 def test_bne_benchmark(benchmark, state):
-    benchmark(control_flow.bne, state, 1, 2, 20)
+    benchmark(control_flow.bne, 1, 2)
 
 def test_jal_benchmark(benchmark, state):
     benchmark(control_flow.jal, state, 40)

--- a/ia_risc_v_npu/tests/unit/risc_v/instructions/test_control_flow.py
+++ b/ia_risc_v_npu/tests/unit/risc_v/instructions/test_control_flow.py
@@ -1,5 +1,5 @@
 import pytest
-from src.risc_v.instructions.control_flow import beq, bne, jal, jalr
+from src.risc_v.instructions.control_flow import beq, bne, blt, bge, bltu, bgeu, jal, jalr
 
 # This is a simplified representation of the processor state for testing purposes.
 class ProcessorState:
@@ -7,18 +7,49 @@ class ProcessorState:
         self.pc = pc
 
 def test_beq():
-    state = ProcessorState()
     # Branch if equal
-    assert beq(state, 10, 10, 20) == 20
+    assert beq(10, 10) == True
     # Don't branch if not equal
-    assert beq(state, 10, 20, 20) == 4
+    assert beq(10, 20) == False
 
 def test_bne():
-    state = ProcessorState()
     # Branch if not equal
-    assert bne(state, 10, 20, 20) == 20
+    assert bne(10, 20) == True
     # Don't branch if equal
-    assert bne(state, 10, 10, 20) == 4
+    assert bne(10, 10) == False
+
+def test_blt():
+    # Signed less than
+    assert blt(10, 20) == True
+    assert blt(-10, 20) == True
+    assert blt(-20, -10) == True
+    assert blt(20, 10) == False
+    assert blt(10, 10) == False
+
+def test_bge():
+    # Signed greater than or equal
+    assert bge(20, 10) == True
+    assert bge(10, 10) == True
+    assert bge(-10, -20) == True
+    assert bge(10, 20) == False
+
+def test_bltu():
+    # Unsigned less than
+    assert bltu(10, 20) == True
+    assert bltu(0, 1) == True
+    assert bltu(20, 10) == False
+    assert bltu(10, 10) == False
+    # Unsigned comparison with negative numbers
+    assert bltu(0xFFFFFFFF, 0) == False # -1 is not less than 0 unsigned
+
+def test_bgeu():
+    # Unsigned greater than or equal
+    assert bgeu(20, 10) == True
+    assert bgeu(10, 10) == True
+    assert bgeu(1, 0) == True
+    assert bgeu(10, 20) == False
+    # Unsigned comparison with negative numbers
+    assert bgeu(0xFFFFFFFF, 0) == True # -1 is greater than 0 unsigned
 
 def test_jal():
     state = ProcessorState()

--- a/ia_risc_v_npu/tests/unit/risc_v/instructions/test_memory.py
+++ b/ia_risc_v_npu/tests/unit/risc_v/instructions/test_memory.py
@@ -1,23 +1,30 @@
 import pytest
 from src.risc_v.instructions.memory import ld, sd, lw, sw
+from src.simulator.memory import SPM
 
 # This is a simplified representation of memory for testing purposes.
-memory = bytearray(1024)
+@pytest.fixture
+def memory():
+    spm = SPM(size_kb=1) # 1KB memory
+    # Initialize with some data for reads
+    for i in range(0, 1024, 4):
+        spm.write(i, (i // 4).to_bytes(4, 'little'))
+    return spm
 
-def test_ld():
+def test_ld(memory):
     # Store a 64-bit value (8 bytes) at address 0
-    memory[0:8] = (1234567890123456789).to_bytes(8, 'little')
+    memory.write(0, (1234567890123456789).to_bytes(8, 'little'))
     assert ld(memory, 0) == 1234567890123456789
 
-def test_sd():
-    sd(memory, 8, 9876543210987654321)
-    assert int.from_bytes(memory[8:16], 'little') == 9876543210987654321
+def test_sd(memory):
+    sd(memory, 8, 0x123456789ABCDEF0)
+    assert int.from_bytes(memory.read(8, 8), 'little') == 0x123456789ABCDEF0
 
-def test_lw():
+def test_lw(memory):
     # Store a 32-bit value (4 bytes) at address 16
-    memory[16:20] = (1234567890).to_bytes(4, 'little')
+    memory.write(16, (1234567890).to_bytes(4, 'little'))
     assert lw(memory, 16) == 1234567890
 
-def test_sw():
+def test_sw(memory):
     sw(memory, 20, 987654321)
-    assert int.from_bytes(memory[20:24], 'little') == 987654321
+    assert int.from_bytes(memory.read(20, 4), 'little') == 987654321

--- a/ia_risc_v_npu/tests/unit/risc_v/test_engine_control_flow.py
+++ b/ia_risc_v_npu/tests/unit/risc_v/test_engine_control_flow.py
@@ -1,0 +1,200 @@
+
+import pytest
+import numpy as np
+from src.risc_v.engine import RISCVEngine
+from src.simulator.memory import Memory
+
+# Helper function to assemble B-type instructions
+def assemble_b_type(funct3, rs1, rs2, imm):
+    imm = imm & 0x1FFF  # Ensure imm is 13 bits
+    imm12 = (imm >> 12) & 1
+    imm11 = (imm >> 11) & 1
+    imm10_5 = (imm >> 5) & 0x3F
+    imm4_1 = (imm >> 1) & 0xF
+    
+    imm_field1 = (imm10_5 << 25) | (rs2 << 20) | (rs1 << 15) | (funct3 << 12) | (imm4_1 << 8) | (imm11 << 7) | 0b1100011
+    imm_field2 = (imm12 << 31)
+    return imm_field2 | imm_field1
+
+# Helper function to assemble J-type instructions
+def assemble_j_type(rd, imm):
+    imm = imm & 0x1FFFFF  # Ensure imm is 21 bits
+    imm20 = (imm >> 20) & 1
+    imm19_12 = (imm >> 12) & 0xFF
+    imm11 = (imm >> 11) & 1
+    imm10_1 = (imm >> 1) & 0x3FF
+
+    return (imm20 << 31) | (imm19_12 << 12) | (imm11 << 20) | (imm10_1 << 21) | (rd << 7) | 0b1101111
+
+
+@pytest.fixture
+def engine():
+    bus = Memory(size=1024 * 1024)  # 1MB memory
+    return RISCVEngine(bus)
+
+def test_jal_positive_offset(engine):
+    # JAL x1, 20 (0x14)
+    # 0x014000ef = jal x1, 20
+    instruction = 0x014000ef
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 20
+    assert engine.registers[1] == 4
+
+def test_jal_negative_offset(engine):
+    # JAL x1, -20 (-0x14)
+    instruction = assemble_j_type(1, -20)
+    engine.bus.write_word(100, instruction)
+    engine.pc = 100
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 80  # 100 - 20
+    assert engine.registers[1] == 104
+
+def test_beq_taken(engine):
+    # BEQ x1, x2, 40
+    engine.registers[1] = 10
+    engine.registers[2] = 10
+    instruction = assemble_b_type(0b000, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 40
+
+def test_beq_not_taken(engine):
+    # BEQ x1, x2, 40
+    engine.registers[1] = 10
+    engine.registers[2] = 20
+    instruction = assemble_b_type(0b000, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 4
+
+def test_bne_taken(engine):
+    # BNE x1, x2, 40
+    engine.registers[1] = 10
+    engine.registers[2] = 20
+    instruction = assemble_b_type(0b001, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 40
+
+def test_bne_not_taken(engine):
+    # BNE x1, x2, 40
+    engine.registers[1] = 10
+    engine.registers[2] = 10
+    instruction = assemble_b_type(0b001, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 4
+
+def test_blt_taken_signed(engine):
+    # BLT x1, x2, 40 (signed)
+    engine.registers[1] = np.int32(-10)
+    engine.registers[2] = np.int32(10)
+    instruction = assemble_b_type(0b100, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 40
+
+def test_blt_not_taken_signed(engine):
+    # BLT x1, x2, 40 (signed)
+    engine.registers[1] = np.int32(10)
+    engine.registers[2] = np.int32(-10)
+    instruction = assemble_b_type(0b100, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 4
+
+def test_bge_taken_signed(engine):
+    # BGE x1, x2, 40 (signed)
+    engine.registers[1] = np.int32(10)
+    engine.registers[2] = np.int32(-10)
+    instruction = assemble_b_type(0b101, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 40
+
+def test_bge_not_taken_signed(engine):
+    # BGE x1, x2, 40 (signed)
+    engine.registers[1] = np.int32(-10)
+    engine.registers[2] = np.int32(10)
+    instruction = assemble_b_type(0b101, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 4
+
+def test_bltu_taken_unsigned(engine):
+    # BLTU x1, x2, 40 (unsigned)
+    engine.registers[1] = 10
+    engine.registers[2] = 20
+    instruction = assemble_b_type(0b110, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 40
+
+def test_bltu_not_taken_unsigned(engine):
+    # BLTU x1, x2, 40 (unsigned)
+    engine.registers[1] = 20
+    engine.registers[2] = 10
+    instruction = assemble_b_type(0b110, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 4
+
+def test_bgeu_taken_unsigned(engine):
+    # BGEU x1, x2, 40 (unsigned)
+    engine.registers[1] = 20
+    engine.registers[2] = 10
+    instruction = assemble_b_type(0b111, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 40
+
+def test_bgeu_not_taken_unsigned(engine):
+    # BGEU x1, x2, 40 (unsigned)
+    engine.registers[1] = 10
+    engine.registers[2] = 20
+    instruction = assemble_b_type(0b111, 1, 2, 40)
+    engine.bus.write_word(0, instruction)
+    engine.pc = 0
+    
+    engine.execute_instruction()
+    
+    assert engine.pc == 4

--- a/ia_risc_v_npu/tests/unit/test_cli.py
+++ b/ia_risc_v_npu/tests/unit/test_cli.py
@@ -1,0 +1,124 @@
+import argparse
+import json
+
+import pytest
+
+from src.simulator.cli import (
+    CLIError,
+    ProgramImage,
+    load_config,
+    load_program_image,
+    run_benchmark,
+    run_simulate,
+)
+
+
+class FakeSection:
+    def __init__(self, addr: int, data: bytes, flags: int = 0x4):
+        self._addr = addr
+        self._data = data
+        self._flags = flags
+
+    def data(self) -> bytes:
+        return self._data
+
+    def __getitem__(self, key: str):
+        if key == "sh_addr":
+            return self._addr
+        if key == "sh_flags":
+            return self._flags
+        raise KeyError(key)
+
+
+class FakeELF:
+    def __init__(self, text_section=None, sections=None):
+        self._text_section = text_section
+        self._sections = sections or []
+
+    def get_section_by_name(self, name: str):
+        if name == ".text":
+            return self._text_section
+        return None
+
+    def iter_sections(self):
+        return iter(self._sections)
+
+
+def test_load_config_reads_json(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"max_cycles": 10}), encoding="utf-8")
+
+    data = load_config(config_path)
+    assert data == {"max_cycles": 10}
+
+
+def test_load_program_image_uses_text_section(tmp_path, monkeypatch):
+    elf_path = tmp_path / "program.elf"
+    elf_path.write_bytes(b"ELF")
+    words = [0xDEADBEEF, 0xCAFEBABE]
+    data = b"".join(word.to_bytes(4, "little") for word in words)
+    fake_section = FakeSection(0x100, data)
+    fake_elf = FakeELF(text_section=fake_section)
+
+    monkeypatch.setattr("src.simulator.cli.ELFFile", lambda _: fake_elf)
+
+    image = load_program_image(elf_path)
+    assert image.instructions == words
+    assert image.text_size == len(data)
+
+
+def test_load_program_image_requires_executable_section(tmp_path, monkeypatch):
+    elf_path = tmp_path / "program.elf"
+    elf_path.write_bytes(b"ELF")
+    fake_elf = FakeELF(text_section=None, sections=[])
+
+    monkeypatch.setattr("src.simulator.cli.ELFFile", lambda _: fake_elf)
+
+    with pytest.raises(CLIError):
+        load_program_image(elf_path)
+
+
+def test_run_simulate_writes_summary(tmp_path, monkeypatch):
+    elf_path = tmp_path / "program.elf"
+    elf_path.write_bytes(b"ELF")
+    output_path = tmp_path / "summary.json"
+
+    program_image = ProgramImage(instructions=[0], text_size=4)
+    monkeypatch.setattr("src.simulator.cli.load_program_image", lambda _: program_image)
+
+    args = argparse.Namespace(
+        elf_file=elf_path,
+        config=None,
+        output=output_path,
+        verbose=False,
+    )
+
+    exit_code = run_simulate(args)
+    assert exit_code == 0
+
+    summary = json.loads(output_path.read_text(encoding="utf-8"))
+    assert summary["halted"] is True
+    assert summary["reason"] == "halt"
+    assert summary["instructions_executed"] == 1
+
+
+def test_run_benchmark_synthetic(tmp_path):
+    output_path = tmp_path / "benchmark.json"
+
+    args = argparse.Namespace(
+        elf_file=None,
+        instructions=1_000,
+        max_cycles=0,
+        config=None,
+        output=output_path,
+        verbose=False,
+    )
+
+    exit_code = run_benchmark(args)
+    assert exit_code == 0
+
+    summary = json.loads(output_path.read_text(encoding="utf-8"))
+    assert summary["halted"] is True
+    assert summary["instructions_executed"] >= args.instructions
+    assert summary["mips"] > 0
+    assert summary["elapsed_seconds"] > 0

--- a/ia_risc_v_npu/tests/verification/test_accuracy.py
+++ b/ia_risc_v_npu/tests/verification/test_accuracy.py
@@ -97,7 +97,7 @@ class TestInstructionAccuracy:
         self.main_engine.pc = 0
         self.ref_engine.registers = self.initial_registers[:]
         self.ref_engine.pc = 0
-        self.dram.fromhex('00' * 1024)
+        self.dram[:] = b'\x00' * len(self.dram)
 
     def compare_states(self):
         assert self.main_engine.pc == self.ref_engine.pc


### PR DESCRIPTION
- feat(cli): add benchmark command for MIPS tracking 커밋으로 CLI에 벤치마크 서브커맨드를 추가하고, 결과 JSON에 elapsed_seconds/mips를 기록하도
  록 했습니다 (ia_risc_v_npu/src/simulator/cli.py:1, ia_risc_v_npu/tests/unit/test_cli.py:1).
  - 시뮬레이터 코어에서 매 사이클 await asyncio.sleep(0) 호출을 제거해 이벤트 루프 오버헤드를 줄였고, 버스/엔진 로깅 정리에 맞춰 테스트도 최     
  신 구조로 업데이트했습니다 (ia_risc_v_npu/src/simulator/main.py:81, ia_risc_v_npu/tests/unit/test_simulator_memory.py:1, ia_risc_v_npu/tests/  
  verification/test_accuracy.py:45).
  - README와 가이드에 새 벤치마크 흐름을 안내하고, T034/T032 현황을 문서화했습니다 (README.md:50, AGENTS.md:6, ia_risc_v_npu/specs/001-ia-risc-  
  v/tasks.md:75).
  - 실제 측정은 python3 -m src.simulator.cli benchmark --instructions 200000 --output results/benchmark_nosleep.json으로 수행했으며, results/    
  benchmark_nosleep.json에 기록된 현재 MIPS는 약 0.28로 목표(12–20 MIPS)에 비해 여전히 낮습니다. 추가 최적화(핵심 연산의 벡터화/Numba화, 더욱 간 
  결한 메모리 경로 등)가 필요합니다