### PR TITLE
fix: address code review findings

### DIFF
--- a/code_review.md
+++ b/code_review.md
@@ -1,0 +1,4 @@
+- [x] 높음 – `alu.div`에서 `np.int32` 사용 시 NumPy 미임포트 위험 → 모듈 임포트 상태를 검증하고 회귀 테스트를 추가했습니다 (`src/risc_v/instructions/alu.py`, `tests/unit/risc_v/instructions/test_alu.py`).
+- [x] 높음 – `lw`가 부호 확장을 수행하지 않음 → 32비트 로드의 부호 확장을 구현하고 음수 경로 테스트를 추가했습니다 (`src/risc_v/instructions/memory.py`, `tests/unit/risc_v/instructions/test_memory.py`).
+- [x] 중간 – 캐시 미스 타이밍이 낙관적 → L1 태그 조회 지연 이후에 하위 계층을 접근하도록 수정했습니다 (`src/simulator/memory.py`).
+- [x] 낮음 – NPU 풀링이 불필요한 복사를 유발 → 벡터 연산이 직접 NumPy 결과를 반환하도록 조정해 중복 복사를 제거했습니다 (`src/npu/model.py`).

--- a/ia_risc_v_npu/src/npu/model.py
+++ b/ia_risc_v_npu/src/npu/model.py
@@ -36,24 +36,16 @@ class NPU:
             self.return_array_to_pool(arr)
 
     def v_add(self, a, b):
-        with self.get_pooled_array(a.shape) as result:
-            np.add(a, b, out=result)
-            return result.copy() # Return a copy to prevent issues if caller holds reference
+        return np.add(a, b)
 
     def v_sub(self, a, b):
-        with self.get_pooled_array(a.shape) as result:
-            np.subtract(a, b, out=result)
-            return result.copy()
+        return np.subtract(a, b)
 
     def v_mul(self, a, b):
-        with self.get_pooled_array(a.shape) as result:
-            np.multiply(a, b, out=result)
-            return result.copy()
+        return np.multiply(a, b)
 
     def v_div(self, a, b):
-        with self.get_pooled_array(a.shape) as result:
-            np.divide(a, b, out=result)
-            return result.copy()
+        return np.divide(a, b)
 
     def execute_operation(self, operation):
         op_type = operation.get("type")
@@ -66,5 +58,4 @@ class NPU:
             raise ValueError(f"Invalid or insufficient operands for operation {op_type}. Expected 2, got {len(operands) if isinstance(operands, list) else 'none'}")
 
         op_func = self._operations[op_type]
-        # The context manager in v_* methods handles returning the array to the pool
         return op_func(operands[0], operands[1])

--- a/ia_risc_v_npu/src/risc_v/instructions/memory.py
+++ b/ia_risc_v_npu/src/risc_v/instructions/memory.py
@@ -7,7 +7,10 @@ def sd(bus, address, value):
     bus.write(address, value.to_bytes(8, 'little'))
 
 def lw(bus, address):
-    return int.from_bytes(bus.read(address, 4), 'little')
+    word = int.from_bytes(bus.read(address, 4), 'little')
+    if word & 0x80000000:
+        return word - (1 << 32)
+    return word
 
 def sw(bus, address, value):
     if isinstance(value, np.uint32):

--- a/ia_risc_v_npu/src/simulator/memory.py
+++ b/ia_risc_v_npu/src/simulator/memory.py
@@ -644,7 +644,7 @@ class MemorySystem:
         next_ready = self._access_hierarchy(
             level_idx + 1,
             address=aligned_address,
-            request_time=request_time,
+            request_time=ready_time,
             access_type="read",
             master_id=master_id,
         )
@@ -652,7 +652,7 @@ class MemorySystem:
         if access_type == "write":
             cache.mark_dirty(new_line)
 
-        fill_complete = max(next_ready, request_time) + cache.hit_latency
+        fill_complete = max(next_ready, ready_time) + cache.hit_latency
 
         if eviction and eviction.dirty and cache.config.write_back:
             writeback_done = self._access_hierarchy(

--- a/ia_risc_v_npu/tests/unit/risc_v/instructions/test_alu.py
+++ b/ia_risc_v_npu/tests/unit/risc_v/instructions/test_alu.py
@@ -1,5 +1,5 @@
 import pytest
-from src.risc_v.instructions.alu import add, sub, and_, or_, xor
+from src.risc_v.instructions.alu import add, sub, and_, or_, xor, div
 
 def test_add():
     assert add(1, 2) == 3
@@ -15,3 +15,9 @@ def test_or():
 
 def test_xor():
     assert xor(0b1010, 0b1100) == 0b0110
+
+
+def test_div_handles_numpy_casting():
+    assert div(10, 2) == 5
+    assert div(-10, 2) == -5
+    assert div(10, -3) == -3

--- a/ia_risc_v_npu/tests/unit/risc_v/instructions/test_memory.py
+++ b/ia_risc_v_npu/tests/unit/risc_v/instructions/test_memory.py
@@ -25,6 +25,11 @@ def test_lw(memory):
     memory.write(16, (1234567890).to_bytes(4, 'little'))
     assert lw(memory, 16) == 1234567890
 
+    # Negative values must be sign-extended from 32 bits
+    neg_value = 0xFFFF_FF10
+    memory.write(24, neg_value.to_bytes(4, 'little'))
+    assert lw(memory, 24) == -240
+
 def test_sw(memory):
     sw(memory, 20, 987654321)
     assert int.from_bytes(memory.read(20, 4), 'little') == 987654321


### PR DESCRIPTION
- lw 부호 확장, 캐시 미스 타이밍, NPU 벡터 연산 복사 제거 등 필요한 코드 수정과 단위 테스트 보강을 반영했습니다.
- PYTHONPATH=$PWD pytest tests/unit/risc_v/instructions/test_memory.py tests/unit/risc_v/instructions/test_alu.py tests/unit/test_npu.py 실행해 관련 테스트가 통과하는 것을 확인