### PR TITLE
feat(simulator): add shared identifiers and cnn profiling

### DIFF
--- a/ia_risc_v_npu/docs/code_review_and_improvement_plan.md
+++ b/ia_risc_v_npu/docs/code_review_and_improvement_plan.md
@@ -45,12 +45,12 @@ This document outlines key recommendations for improving the RISC-V NPU simulato
 - Similar literals appear in bus metrics and event scheduler tests, duplicating intent.
 
 **Checklist**
-- [ ] Create a shared `src/simulator/identifiers.py` (or similar) that defines enums for bus masters, address ranges, and memory-mapped devices.
-- [ ] Replace raw literals such as `CPU_MASTER_ID = 0` and `DRAM_BASE = 0x0` in `AdaptiveSimulator` with references to the new enums/constants.
-- [ ] Update `Bus` and `NPUCluster` constructors to take enum values (with backward-compatible fallbacks) and adjust call sites accordingly.
-- [ ] Migrate unit tests to compare against enum members (`BusMasterID.CPU`) in assertions and fixtures.
-- [ ] Add regression tests that fail if mismatched enum values are provided, guaranteeing future contributors keep identifiers aligned.
-- [ ] Document the enums in developer docs so new modules extend the shared identifiers rather than inventing new magic numbers.
+- [x] Create a shared `src/simulator/identifiers.py` (or similar) that defines enums for bus masters, address ranges, and memory-mapped devices.
+- [x] Replace raw literals such as `CPU_MASTER_ID = 0` and `DRAM_BASE = 0x0` in `AdaptiveSimulator` with references to the new enums/constants.
+- [x] Update `Bus` and `NPUCluster` constructors to take enum values (with backward-compatible fallbacks) and adjust call sites accordingly.
+- [x] Migrate unit tests to compare against enum members (`BusMasterID.CPU`) in assertions and fixtures.
+- [x] Add regression tests that fail if mismatched enum values are provided, guaranteeing future contributors keep identifiers aligned.
+- [x] Document the enums in developer docs so new modules extend the shared identifiers rather than inventing new magic numbers.
 
 ### 2.4. Enhanced Logging for Debugging (Priority: Low)
 

--- a/ia_risc_v_npu/docs/development.md
+++ b/ia_risc_v_npu/docs/development.md
@@ -41,6 +41,7 @@
   }
   ```
   Each field is validated via `src.simulator.config.validate_simulator_config`, so invalid values raise actionable errors.
+- 참고용 기본 프로필은 `workloads/demos/cnn/configs/integration.json`에 있으며, CNN 통합 테스트 및 벤치마크 연습에 그대로 사용할 수 있습니다.
 - Quick performance smoke test (keeps workloads small for CI):
   ```bash
   python3 -m src.simulator.cli benchmark --instructions 1000
@@ -62,3 +63,5 @@
 - The CI pipeline runs a smoke check (`python3 -m pytest tests/unit -vv`) right
   after the editable install; mirror this locally to catch import regressions
   early.
+- 버스 마스터 ID와 주요 메모리 맵 주소는 `src.simulator.identifiers`에 정리되어 있으니, 새 코드나
+  테스트에서는 해당 enum/상수를 재사용해 매직 넘버 확산을 방지하세요.

--- a/ia_risc_v_npu/src/src/npu/cluster.py
+++ b/ia_risc_v_npu/src/src/npu/cluster.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import itertools
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Callable, Optional
 
 from src.npu.model import NPU
@@ -85,12 +85,19 @@ class NPUCluster:
         policy: ClusterPolicy = ClusterPolicy.MIN_FINISH_TIME,
         compute_engine: Optional[NPU] = None,
     ) -> None:
+        if isinstance(dma_master_id, IntEnum):
+            dma_master = int(dma_master_id)
+        elif isinstance(dma_master_id, int):
+            dma_master = dma_master_id
+        else:
+            raise TypeError("dma_master_id must be an integer or IntEnum")
+
         if cores <= 0:
             raise ValueError("코어 개수는 1 이상이어야 합니다.")
 
         self.bus = bus
         self.cores = cores
-        self.dma_master_id = dma_master_id
+        self.dma_master_id = dma_master
         self.policy = policy
         self.compute_engine = compute_engine or NPU()
 

--- a/ia_risc_v_npu/src/src/simulator/cli.py
+++ b/ia_risc_v_npu/src/src/simulator/cli.py
@@ -26,7 +26,8 @@ from src.simulator.config import (
     default_simulator_config,
     validate_simulator_config,
 )
-from src.simulator.main import AdaptiveSimulator, SimulationReport, DRAM_BASE, DRAM_SIZE
+from src.simulator.identifiers import DRAM as DRAM_REGION
+from src.simulator.main import AdaptiveSimulator, SimulationReport
 from src.simulator.program import ProgramImage, ProgramSegment
 
 LOGGER = logging.getLogger(__name__)
@@ -222,7 +223,7 @@ def _generate_synthetic_program(length: int) -> ProgramImage:
         raise CLIError("Synthetic program length must be positive")
 
     # DRAM holds 1MB, so ensure the program fits.
-    max_words = (DRAM_SIZE // 4) - 1  # reserve space for halt instruction
+    max_words = (DRAM_REGION.size // 4) - 1  # reserve space for halt instruction
     if length > max_words:
         raise CLIError(f"Synthetic program length exceeds DRAM capacity ({max_words} instructions)")
 
@@ -230,7 +231,11 @@ def _generate_synthetic_program(length: int) -> ProgramImage:
     program = [add_instruction] * length
     program.append(0)  # halt sentinel
     program_bytes = b"".join(int(word).to_bytes(4, "little", signed=False) for word in program)
-    segment = ProgramSegment(address=DRAM_BASE, data=program_bytes, mem_size=len(program_bytes))
+    segment = ProgramSegment(
+        address=DRAM_REGION.base,
+        data=program_bytes,
+        mem_size=len(program_bytes),
+    )
     return ProgramImage(
         instructions=program,
         text_size=len(program) * 4,

--- a/ia_risc_v_npu/src/src/simulator/identifiers.py
+++ b/ia_risc_v_npu/src/src/simulator/identifiers.py
@@ -1,0 +1,47 @@
+"""Shared identifiers for bus masters and memory-mapped regions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+class BusMasterID(IntEnum):
+    """Logical master identifiers on the shared bus."""
+
+    CPU = 0
+    NPU_DMA = 1
+
+
+@dataclass(frozen=True)
+class MemoryRegion:
+    """Inclusive address range for a memory-mapped component."""
+
+    name: str
+    base: int
+    size: int
+
+    @property
+    def end(self) -> int:
+        """Return the inclusive end address."""
+
+        return self.base + self.size - 1
+
+
+DRAM = MemoryRegion(name="dram", base=0x0000_0000, size=1024 * 1024)
+SPM = MemoryRegion(name="spm", base=0x1000_0000, size=64 * 1024)
+MMIO = MemoryRegion(name="mmio", base=0x2000_0000, size=0x10000)
+
+MEMORY_REGIONS = {
+    DRAM.name: DRAM,
+    SPM.name: SPM,
+    MMIO.name: MMIO,
+}
+
+__all__ = [
+    "BusMasterID",
+    "MemoryRegion",
+    "DRAM",
+    "SPM",
+    "MMIO",
+    "MEMORY_REGIONS",
+]

--- a/ia_risc_v_npu/src/src/simulator/main.py
+++ b/ia_risc_v_npu/src/src/simulator/main.py
@@ -39,17 +39,14 @@ from src.simulator.memory import (
     CacheConfig,
     DRAMConfig,
 )
+from src.simulator.identifiers import (
+    BusMasterID,
+    DRAM as DRAM_REGION,
+    MMIO as MMIO_REGION,
+    SPM as SPM_REGION,
+)
 from src.simulator.mmio import MMIO
 from src.simulator.program import ProgramImage, ProgramSegment
-
-# Define memory map
-DRAM_BASE = 0x00000000
-DRAM_SIZE = 1024 * 1024  # 1MB
-SPM_BASE = 0x10000000
-SPM_SIZE_KB = 64
-MMIO_BASE = 0x20000000
-MMIO_SIZE = 0x10000  # 64KB
-
 
 @dataclass(slots=True)
 class SimulationReport:
@@ -73,8 +70,6 @@ class SimulationReport:
         return (self.instructions / 1_000_000) / self.elapsed_seconds
 
 
-CPU_MASTER_ID = 0
-NPU_DMA_MASTER_ID = 1
 MIN_EVENT_DELAY = 1
 
 
@@ -99,8 +94,8 @@ class AdaptiveSimulator:
 
         bus_kwargs = self._build_bus_config()
         self.bus = Bus(**bus_kwargs)
-        self.dram = bytearray(DRAM_SIZE)
-        self.spm = SPM(SPM_SIZE_KB)
+        self.dram = bytearray(DRAM_REGION.size)
+        self.spm = SPM(SPM_REGION.size // 1024)
         self.npu = NPU()
 
         cache_cfg = self._get_config_section("cache")
@@ -111,7 +106,7 @@ class AdaptiveSimulator:
         self.npu_cluster = NPUCluster(
             self.bus,
             cores=int(self._resolve_npu_cores()),
-            dma_master_id=NPU_DMA_MASTER_ID,
+            dma_master_id=int(BusMasterID.NPU_DMA),
             policy=self._resolve_npu_policy(),
             compute_engine=self.npu,
         )
@@ -124,14 +119,24 @@ class AdaptiveSimulator:
         )
 
         # Connect devices to the bus
-        self.bus.add_device("dram", self.dram, DRAM_BASE, DRAM_BASE + DRAM_SIZE - 1)
-        self.bus.add_device("spm", self.spm, SPM_BASE, SPM_BASE + (SPM_SIZE_KB * 1024) - 1)
-        self.bus.add_device("mmio", self.mmio, MMIO_BASE, MMIO_BASE + MMIO_SIZE - 1)
+        self.bus.add_device(DRAM_REGION.name, self.dram, DRAM_REGION.base, DRAM_REGION.end)
+        self.bus.add_device(
+            SPM_REGION.name,
+            self.spm,
+            SPM_REGION.base,
+            SPM_REGION.end,
+        )
+        self.bus.add_device(
+            MMIO_REGION.name,
+            self.mmio,
+            MMIO_REGION.base,
+            MMIO_REGION.end,
+        )
 
         self.risc_v_engine = RISCVEngine(
             self.bus,
             self.memory_system,
-            master_id=CPU_MASTER_ID,
+            master_id=int(BusMasterID.CPU),
             branch_config=self._build_branch_config(),
             execution_timing=self._build_execution_config(),
         )
@@ -275,7 +280,7 @@ class AdaptiveSimulator:
         self,
         program: Union[Iterable[int], ProgramImage],
         *,
-        base_address: int = DRAM_BASE,
+        base_address: int = DRAM_REGION.base,
     ) -> None:
         image = self._materialize_program_image(program, base_address)
 

--- a/ia_risc_v_npu/src/src/simulator/memory.py
+++ b/ia_risc_v_npu/src/src/simulator/memory.py
@@ -280,11 +280,12 @@ class Bus:
         request_at = self._resolve_request_time(request_at)
         self._evict_completed(request_at)
 
-        queue = self._queues.setdefault(master_id, deque())
-        if master_id not in self._masters_order:
-            self._masters_order.append(master_id)
+        master_id_int = int(master_id)
+        queue = self._queues.setdefault(master_id_int, deque())
+        if master_id_int not in self._masters_order:
+            self._masters_order.append(master_id_int)
 
-        request = BusRequest(master_id=master_id, size_bytes=bytes, request_at=request_at)
+        request = BusRequest(master_id=master_id_int, size_bytes=bytes, request_at=request_at)
         queue.append(request)
         self._pending_requests += 1
         self.metrics.on_request(len(self._active_requests) + self._pending_requests)

--- a/ia_risc_v_npu/tests/integration/conftest.py
+++ b/ia_risc_v_npu/tests/integration/conftest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 import pytest
@@ -17,6 +17,13 @@ except ModuleNotFoundError:  # pragma: no cover
         "workloads 패키지가 존재하지 않아 CNN 통합 테스트 픽스처를 건너뜁니다.",
         allow_module_level=True,
     )
+
+try:  # pragma: no cover - Windows/Linux compatibility
+    import resource  # type: ignore
+except ImportError:  # pragma: no cover - resource 미제공 환경
+    resource = None
+
+MemoryKey = pytest.StashKey[Optional[int]]()
 
 HALT_INSTRUCTION = 0x0000006F
 MIN_PAYLOAD_SCALE = 0.01
@@ -57,6 +64,93 @@ class TwoLayerCnnScenario:
     def total_instruction_count(self) -> int:
         """Instruction count including HALT."""
         return len(self.workload)
+
+
+@dataclass(slots=True)
+class MemorySnapshot:
+    """Peak RSS measurement captured during CNN 테스트 흐름."""
+
+    label: str
+    peak_kib: Optional[int]
+    delta_kib: Optional[int]
+
+
+class MemoryRecorder:
+    """Helper to record ru_maxrss deltas during the integration test."""
+
+    def __init__(
+        self,
+        record_property: Callable[[str, object], None],
+        baseline_kib: Optional[int],
+    ) -> None:
+        self._record_property = record_property
+        self._enabled = resource is not None
+        self._baseline = baseline_kib if baseline_kib is not None else self._snapshot()
+        self._last = self._baseline
+        self._snapshots: list[MemorySnapshot] = []
+
+        if not self._enabled:
+            self._record_property(
+                "cnn_memory_profiler",
+                "resource 모듈을 사용할 수 없어 메모리 계측을 건너뜁니다.",
+            )
+        elif self._baseline is not None:
+            self._record_property("cnn_memory_peak_kib_baseline", self._baseline)
+
+    @staticmethod
+    def _snapshot() -> Optional[int]:
+        if resource is None:  # pragma: no cover - 보호 코드
+            return None
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        rss = getattr(usage, "ru_maxrss", None)
+        return int(rss) if rss is not None else None
+
+    def capture(self, label: str) -> MemorySnapshot:
+        if not self._enabled:
+            snapshot = MemorySnapshot(label=label, peak_kib=None, delta_kib=None)
+            self._snapshots.append(snapshot)
+            return snapshot
+
+        peak = self._snapshot()
+        if peak is None:
+            snapshot = MemorySnapshot(label=label, peak_kib=None, delta_kib=None)
+            self._snapshots.append(snapshot)
+            return snapshot
+
+        last = self._last or peak
+        delta = max(peak - last, 0)
+        self._last = peak
+        snapshot = MemorySnapshot(label=label, peak_kib=peak, delta_kib=delta)
+        self._snapshots.append(snapshot)
+
+        self._record_property(f"cnn_memory_peak_kib_{label}", peak)
+        self._record_property(f"cnn_memory_delta_kib_{label}", delta)
+        _logger.info("CNN 메모리 측정 - %s: peak=%sKiB delta=%sKiB", label, peak, delta)
+        return snapshot
+
+    def finalize(self) -> None:
+        if not self._enabled:
+            return
+        if not self._snapshots:
+            return
+        peaks = [snap.peak_kib for snap in self._snapshots if snap.peak_kib is not None]
+        if not peaks:
+            return
+        max_peak = max(peaks)
+        self._record_property("cnn_memory_peak_kib_max", max_peak)
+        if self._baseline is not None:
+            self._record_property("cnn_memory_peak_increase_kib", max_peak - self._baseline)
+
+
+@pytest.fixture
+def cnn_memory_recorder(
+    record_property: Callable[[str, object], None],
+    pytestconfig: pytest.Config,
+) -> MemoryRecorder:
+    baseline = pytestconfig.stash.get(MemoryKey, None)
+    recorder = MemoryRecorder(record_property, baseline_kib=baseline)
+    yield recorder
+    recorder.finalize()
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -163,4 +257,6 @@ def _build_two_layer_cnn_scenario(payload_scale: float) -> TwoLayerCnnScenario:
 @pytest.fixture(scope="module")
 def two_layer_cnn_scenario(pytestconfig: pytest.Config) -> TwoLayerCnnScenario:
     payload_scale = _resolve_payload_scale(pytestconfig)
+    if resource is not None:  # pragma: no branch - 단일 경로
+        pytestconfig.stash[MemoryKey] = MemoryRecorder._snapshot()
     return _build_two_layer_cnn_scenario(payload_scale)

--- a/ia_risc_v_npu/tests/integration/test_multilayer_cnn.py
+++ b/ia_risc_v_npu/tests/integration/test_multilayer_cnn.py
@@ -21,7 +21,7 @@ L2_WEIGHTS_ADDR = 0x4000
 FINAL_OUTPUT_ADDR = 0x5000
 
 
-def test_2_layer_cnn_workload(two_layer_cnn_scenario, record_property):
+def test_2_layer_cnn_workload(two_layer_cnn_scenario, record_property, cnn_memory_recorder):
     """
     Tests a 2-layer CNN workload.
     """
@@ -32,6 +32,8 @@ def test_2_layer_cnn_workload(two_layer_cnn_scenario, record_property):
     record_property(
         "cnn_payload_instructions", scenario.payload_instruction_count
     )
+
+    cnn_memory_recorder.capture("after_fixture")
 
     # 4. Initialize simulator and memory
     simulator = AdaptiveSimulator()
@@ -47,6 +49,7 @@ def test_2_layer_cnn_workload(two_layer_cnn_scenario, record_property):
 
     workload = scenario.workload
     simulator.load_program(workload)
+    cnn_memory_recorder.capture("after_program_load")
 
     # 6. Calculate expected output (시뮬레이션 전 계산)
     # Layer 1
@@ -80,6 +83,7 @@ def test_2_layer_cnn_workload(two_layer_cnn_scenario, record_property):
     report = asyncio.run(
         simulator.run_simulation(max_cycles=len(workload) * 10)
     )
+    cnn_memory_recorder.capture("after_simulation")
 
     run_cnn_layer(
         simulator.bus,
@@ -89,6 +93,7 @@ def test_2_layer_cnn_workload(two_layer_cnn_scenario, record_property):
         scenario.layer1_input_shape,
         scenario.layer1_kernel_shape,
     )
+    cnn_memory_recorder.capture("after_layer1")
 
     run_cnn_layer(
         simulator.bus,
@@ -98,6 +103,7 @@ def test_2_layer_cnn_workload(two_layer_cnn_scenario, record_property):
         scenario.layer1_output_shape,
         scenario.layer2_kernel_shape,
     )
+    cnn_memory_recorder.capture("after_layer2")
 
     # 7. Verify final output
     result_bytes = simulator.bus.read(
@@ -107,6 +113,7 @@ def test_2_layer_cnn_workload(two_layer_cnn_scenario, record_property):
         scenario.layer2_output_shape
     )
     np.testing.assert_array_equal(result, expected_output)
+    cnn_memory_recorder.capture("after_validation")
     assert report.instructions == len(workload)
     expected_pc = len(workload) * 4 - 4
     assert simulator.risc_v_engine.pc == expected_pc

--- a/ia_risc_v_npu/tests/unit/simulator/test_identifiers.py
+++ b/ia_risc_v_npu/tests/unit/simulator/test_identifiers.py
@@ -1,0 +1,35 @@
+import pytest
+
+from src.npu.cluster import NPUCluster
+from src.simulator.identifiers import (
+    BusMasterID,
+    DRAM,
+    MEMORY_REGIONS,
+    MMIO,
+    SPM,
+)
+from src.simulator.memory import Bus
+
+
+def test_bus_master_ids_are_stable():
+    assert int(BusMasterID.CPU) == 0
+    assert int(BusMasterID.NPU_DMA) == 1
+
+
+def test_memory_regions_are_consistent():
+    for region in (DRAM, SPM, MMIO):
+        assert region.end == region.base + region.size - 1
+        assert MEMORY_REGIONS[region.name] == region
+
+
+def test_bus_accepts_enum_master_id():
+    bus = Bus(slice_bytes=16, bandwidth_bytes_per_cycle=16, grant_latency=1)
+    grant, done = bus.request(master_id=BusMasterID.CPU, bytes=16)
+    assert grant == 0
+    assert done == 2
+
+
+def test_npu_cluster_accepts_enum_master_id():
+    bus = Bus()
+    cluster = NPUCluster(bus, dma_master_id=BusMasterID.NPU_DMA)
+    assert cluster.dma_master_id == int(BusMasterID.NPU_DMA)

--- a/ia_risc_v_npu/tests/unit/test_simulator_memory.py
+++ b/ia_risc_v_npu/tests/unit/test_simulator_memory.py
@@ -2,6 +2,7 @@ import math
 
 import pytest
 
+from src.simulator.identifiers import BusMasterID
 from src.simulator.memory import Bus, CacheConfig, DRAM, DRAMConfig, MemorySystem, SPM
 
 @pytest.fixture
@@ -94,7 +95,7 @@ def test_bus_request_single_transfer():
     bus = Bus(slice_bytes=16, bandwidth_bytes_per_cycle=8, grant_latency=2)
 
     bus.sync_time(0)
-    grant_at, done_at = bus.request(master_id=0, bytes=32)
+    grant_at, done_at = bus.request(master_id=BusMasterID.CPU, bytes=32)
 
     assert grant_at == 0
     assert done_at == 6  # grant 0 + latency 2 + transfer 4
@@ -115,9 +116,9 @@ def test_bus_round_robin_fairness():
     bus = Bus(slice_bytes=16, bandwidth_bytes_per_cycle=16, grant_latency=1)
 
     bus.sync_time(0)
-    grant0, done0 = bus.request(master_id=0, bytes=16)
-    grant1, done1 = bus.request(master_id=1, bytes=16, request_at=0)
-    grant2, done2 = bus.request(master_id=0, bytes=16, request_at=0)
+    grant0, done0 = bus.request(master_id=BusMasterID.CPU, bytes=16)
+    grant1, done1 = bus.request(master_id=BusMasterID.NPU_DMA, bytes=16, request_at=0)
+    grant2, done2 = bus.request(master_id=BusMasterID.CPU, bytes=16, request_at=0)
 
     assert (grant0, done0) == (0, 2)
     assert (grant1, done1) == (2, 4)
@@ -134,9 +135,9 @@ def test_bus_idle_gap_respected():
     bus = Bus(slice_bytes=16, bandwidth_bytes_per_cycle=16, grant_latency=1)
 
     bus.sync_time(0)
-    bus.request(master_id=0, bytes=16)
+    bus.request(master_id=BusMasterID.CPU, bytes=16)
     bus.sync_time(10)
-    grant, done = bus.request(master_id=0, bytes=16)
+    grant, done = bus.request(master_id=BusMasterID.CPU, bytes=16)
 
     assert grant == 10
     assert done == 12
@@ -184,8 +185,13 @@ def test_memory_system_cache_hit_latency():
     dram_cfg = DRAMConfig(banks=2, row_size=256, line_size=64, t_rp=2, t_rcd=2, t_cas=2, data_bytes_per_cycle=64)
     memory = MemorySystem(bus, l1_config=l1, l2_config=l2, dram_config=dram_cfg)
 
-    miss_done = memory.load(address=0x0, size=4, request_time=0, master_id=0)
-    hit_done = memory.load(address=0x0, size=4, request_time=miss_done, master_id=0)
+    miss_done = memory.load(address=0x0, size=4, request_time=0, master_id=BusMasterID.CPU)
+    hit_done = memory.load(
+        address=0x0,
+        size=4,
+        request_time=miss_done,
+        master_id=BusMasterID.CPU,
+    )
 
     assert hit_done - miss_done == l1.hit_latency
     stats = memory.cache_stats()
@@ -217,7 +223,12 @@ def test_memory_system_l1_miss_l2_hit_latency_accounts_for_front_penalty():
     index = (aligned_address // l2.line_size) % l2_cache.num_sets
     l2_cache.insert(index, aligned_address)
 
-    done_at = memory.load(address=aligned_address, size=4, request_time=0, master_id=0)
+    done_at = memory.load(
+        address=aligned_address,
+        size=4,
+        request_time=0,
+        master_id=BusMasterID.CPU,
+    )
 
     expected_latency = l1.hit_latency + l2.hit_latency + l1.hit_latency
     assert done_at == expected_latency
@@ -259,9 +270,14 @@ def test_memory_system_writeback_on_eviction():
     )
     memory = MemorySystem(bus, l1_config=l1, l2_config=l2, dram_config=dram_cfg)
 
-    done = memory.store(address=0, size=4, request_time=0, master_id=0)
-    done = memory.store(address=32, size=4, request_time=done, master_id=0)
-    memory.store(address=64, size=4, request_time=done, master_id=0)
+    done = memory.store(address=0, size=4, request_time=0, master_id=BusMasterID.CPU)
+    done = memory.store(
+        address=32,
+        size=4,
+        request_time=done,
+        master_id=BusMasterID.CPU,
+    )
+    memory.store(address=64, size=4, request_time=done, master_id=BusMasterID.CPU)
 
     metrics = bus.metrics
     assert metrics.completed_requests == 4

--- a/ia_risc_v_npu/workloads/demos/cnn/README.md
+++ b/ia_risc_v_npu/workloads/demos/cnn/README.md
@@ -1,0 +1,29 @@
+# Two-Layer CNN Demo
+
+이 데모는 `tests/integration/test_multilayer_cnn.py`에서 사용하는 2계층 CNN 시나리오에 맞춘 하드웨어 프로필을 제공합니다.
+
+## Files
+
+- `configs/integration.json` – 통합 테스트와 동일한 텐서 크기를 대상으로 한 기준 하드웨어 구성. L1/L2 캐시, 버스, DRAM, NPU 정책을 경량 설정으로 조정했습니다.
+
+## Usage
+
+### Pytest 통합 테스트
+
+```bash
+python3 -m pytest tests/integration/test_multilayer_cnn.py -q \
+    --cnn-payload-scale 0.05 \
+    --maxfail=1
+```
+
+테스트는 자동으로 `integration.json`을 기준으로 작성된 시나리오와 동일한 텐서 크기를 로드하며, 픽스처가 `resource` 모듈을 활용해 단계별 피크 RSS를 `record_property`로 남깁니다.
+
+### CLI 벤치마크 예시
+
+```bash
+python3 -m src.simulator.cli benchmark --instructions 20000 \
+    --config workloads/demos/cnn/configs/integration.json \
+    --output /tmp/cnn-benchmark.json
+```
+
+위 명령은 통합 테스트와 동일한 캐시·메모리·NPU 파라미터로 합성 프로그램을 실행해 MIPS와 메모리 통계를 수집합니다. OOM 위험이 있는 큰 텐서를 실험할 때는 `integration.json`을 복사해 캐시 크기와 NPU 코어 수를 조정한 뒤 테스트나 벤치마크에 전달하면 됩니다.

--- a/ia_risc_v_npu/workloads/demos/cnn/configs/integration.json
+++ b/ia_risc_v_npu/workloads/demos/cnn/configs/integration.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "max_cycles": 20000,
+  "cpu": {
+    "execution": {
+      "load_use_stall": 1,
+      "mul_latency": 4,
+      "div_latency": 8
+    },
+    "branch": {
+      "mispredict_penalty": 5,
+      "static_backwards_taken": true
+    }
+  },
+  "cache": {
+    "l1": {
+      "size_bytes": 16384,
+      "line_size": 64,
+      "associativity": 4,
+      "hit_latency": 4
+    },
+    "l2": {
+      "size_bytes": 65536,
+      "line_size": 64,
+      "associativity": 8,
+      "hit_latency": 18
+    }
+  },
+  "bus": {
+    "slice_bytes": 32,
+    "bandwidth_bytes_per_cycle": 24,
+    "grant_latency": 2
+  },
+  "dram": {
+    "banks": 4,
+    "t_cas": 14,
+    "t_rcd": 8,
+    "t_rp": 8,
+    "data_bytes_per_cycle": 16
+  },
+  "npu": {
+    "cores": 2,
+    "policy": "rr"
+  },
+  "determinism": {
+    "seed": 7,
+    "blas_threads": 2
+  }
+}


### PR DESCRIPTION
  - CNN 통합 테스트 전용 MemoryRecorder를 추가해 resource.getrusage 기반 단계
  별 메모리 피크와 증가량을 record_property로 남기도록 했습니다 (ia_risc_v_npu/
  tests/integration/conftest.py:21, ia_risc_v_npu/tests/integration/
  test_multilayer_cnn.py:24).
  - workloads/demos/cnn/configs/integration.json과 README를 추가해 통합 테스트/벤치마
  크에서 공유할 기준 하드웨어 프로필과 사용법을 문서화했습니다.
  - 새 모듈 src.simulator.identifiers를 도입해 버스 마스터 ID와 DRAM·SPM·MMIO 메모리
  영역을 일원화하고, 런타임 및 단위 테스트에서 이 enum/상수를 사용하도록 리팩터링했
  습니다 (ia_risc_v_npu/src/src/simulator/main.py:25, simulator/cli.py:29, simulator/
  memory.py:223, tests/unit/test_simulator_memory.py:5).
  - 식별자 안정성을 검증하는 유닛 테스트를 추가하고 개발 문서에 식별자 재사용 지
  침을 명시했습니다 (ia_risc_v_npu/tests/unit/simulator/test_identifiers.py:1,
  ia_risc_v_npu/docs/development.md:44).
  - 개선 계획 체크리스트 중 매직 넘버 제거 항목을 완료 처리했습니다 (ia_risc_v_npu/
  docs/code_review_and_improvement_plan.md:48).