### PR TITLE
feat(workloads): add deterministic CNN asset generator

### DIFF
--- a/ia_risc_v_npu/docs/code_review_and_improvement_plan.md
+++ b/ia_risc_v_npu/docs/code_review_and_improvement_plan.md
@@ -78,4 +78,4 @@ This document outlines key recommendations for improving the RISC-V NPU simulato
 - [x] Update onboarding docs (`README.md`, `docs/development.md`) with the editable install workflow, explicit `python3` usage, and common CLI/test commands.
 - [ ] Add CI or pre-commit jobs to run `black --check` and `ruff`, aligning with the existing `pyproject.toml` configuration.
 - [x] Document a lightweight benchmark smoke test (e.g., `python -m src.simulator.cli benchmark --instructions 1000`) and consider wiring it as an optional CI stage to catch major regressions.
-- [ ] Provide deterministic workload generation scripts under `workloads/` along with instructions for regenerating large tensors to keep version control lean.
+- [x] Provide deterministic workload generation scripts under `workloads/` along with instructions for regenerating large tensors to keep version control lean.

--- a/ia_risc_v_npu/docs/development.md
+++ b/ia_risc_v_npu/docs/development.md
@@ -39,6 +39,14 @@
   Enable richer allocation traces with `CNN_MEMORY_TRACE=1` (or the flag above),
   adjust the stack depth via `CNN_MEMORY_TRACE_FRAMES`, and control the number
   of reported hot spots with `CNN_MEMORY_TRACE_TOP`.
+- Regenerate deterministic CNN tensors and instruction streams when you need to
+  rehydrate the integration workload assets:
+  ```bash
+  python3 -m workloads.generators.generate_two_layer_cnn_assets \
+      --output-dir workloads/generated/two_layer_cnn --payload-scale 0.05
+  ```
+  Use `--force` to overwrite an existing directory and `--dtype` to experiment
+  with alternative integer widths.
 - Override hardware profiles by editing the JSON passed to `--config`:
   ```json
   {

--- a/ia_risc_v_npu/workloads/README.md
+++ b/ia_risc_v_npu/workloads/README.md
@@ -1,0 +1,52 @@
+# Workload Assets Guide
+
+The `workloads/` package hosts reproducible generators, demo configurations, and
+profiling utilities used across the simulator tests and documentation. Generated
+artifacts stay out of version control; use the helper scripts to recreate them
+on demand.
+
+## Directory Overview
+
+- `demos/` – reference workloads paired with ready-to-run JSON configs.
+- `generators/` – deterministic asset builders.
+- `generated/` – default drop location for regenerated tensors and programs
+  (ignored by git).
+- `profiling/` – utilities for collecting trace data during performance
+  experiments.
+
+## Two-Layer CNN Assets
+
+Use the generator below to reproduce the tensors and instruction stream consumed
+by `tests/integration/test_multilayer_cnn.py` and the CNN demo configs:
+
+```bash
+python3 -m workloads.generators.generate_two_layer_cnn_assets \
+  --output-dir workloads/generated/two_layer_cnn \
+  --payload-scale 0.05
+```
+
+The command emits:
+
+- `input.npy` – 1×5×5 activation tensor (`uint32`).
+- `layer1_weights.npy` – first-layer kernels shaped 2×1×3×3.
+- `layer2_weights.npy` – second-layer kernels shaped 3×2×2×2.
+- `program.npy` – concatenated synthetic NOP payload followed by the halt
+  instruction.
+- `metadata.json` – shapes, payload scale, and bookkeeping data.
+
+All arrays are seeded with `np.arange` to keep results deterministic. Adjust the
+`--payload-scale` flag when you want to stress-test longer synthetic programs.
+Add `--force` to overwrite an existing output directory, and pass `--dtype` to
+experiment with alternative integer widths.
+
+## Regeneration Checklist
+
+1. Create or update your virtual environment and install the project in editable
+   mode (`python3 -m pip install -e ia_risc_v_npu[dev]`).
+2. Regenerate the required assets with the appropriate script from
+   `workloads/generators/`.
+3. Store the outputs under `workloads/generated/` (or another ignored
+   directory). Avoid committing these binaries—record only the script changes
+   and supporting configs.
+4. Document any new generator or usage flow in this README so other contributors
+   can reproduce identical tensors.

--- a/ia_risc_v_npu/workloads/generated/.gitignore
+++ b/ia_risc_v_npu/workloads/generated/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated workload artifacts
+*
+!.gitignore

--- a/ia_risc_v_npu/workloads/generators/__init__.py
+++ b/ia_risc_v_npu/workloads/generators/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for generating deterministic workload artifacts."""

--- a/ia_risc_v_npu/workloads/generators/generate_two_layer_cnn_assets.py
+++ b/ia_risc_v_npu/workloads/generators/generate_two_layer_cnn_assets.py
@@ -1,0 +1,172 @@
+"""Generate deterministic assets for the two-layer CNN integration workload."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Tuple
+
+import numpy as np
+
+try:
+    from workloads.cnn_workload import generate_cnn_workload
+except ModuleNotFoundError:  # pragma: no cover - best effort direct execution guard
+    import sys
+
+    package_root = Path(__file__).resolve().parents[2]
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+    src_root = package_root / "src"
+    if src_root.exists() and str(src_root) not in sys.path:
+        sys.path.insert(0, str(src_root))
+    from workloads.cnn_workload import generate_cnn_workload
+
+HALT_INSTRUCTION = 0x0000006F
+DEFAULT_OUTPUT_DIR = Path("workloads/generated/two_layer_cnn")
+LAYER1_INPUT_SHAPE = (1, 5, 5)
+LAYER1_KERNEL_SHAPE = (2, 1, 3, 3)
+LAYER2_KERNEL_SHAPE = (3, 2, 2, 2)
+
+
+@dataclass(frozen=True)
+class CnnAssetMetadata:
+    layer1_input_shape: Tuple[int, int, int]
+    layer1_kernel_shape: Tuple[int, int, int, int]
+    layer2_kernel_shape: Tuple[int, int, int, int]
+    layer1_output_shape: Tuple[int, int, int]
+    layer2_output_shape: Tuple[int, int, int]
+    payload_scale: float
+    halt_instruction: int
+    dtype: str
+    program_length: int
+
+
+def _derive_output_shape(input_shape: Tuple[int, int, int], kernel_shape: Tuple[int, int, int, int]) -> Tuple[int, int, int]:
+    channels, height, width = input_shape
+    _, _, kernel_h, kernel_w = kernel_shape
+    output_h = height - kernel_h + 1
+    output_w = width - kernel_w + 1
+    return kernel_shape[0], output_h, output_w
+
+
+def _ensure_output_dir(path: Path, *, force: bool) -> None:
+    if path.exists():
+        if not path.is_dir():
+            raise SystemExit(f"{path} is not a directory")
+        if any(path.iterdir()) and not force:
+            raise SystemExit(
+                f"{path} already contains files. Re-run with --force to overwrite."
+            )
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _build_tensors(dtype: np.dtype) -> Dict[str, np.ndarray]:
+    input_data = np.arange(1, np.prod(LAYER1_INPUT_SHAPE) + 1, dtype=dtype).reshape(LAYER1_INPUT_SHAPE)
+    layer1_weights = np.arange(1, np.prod(LAYER1_KERNEL_SHAPE) + 1, dtype=dtype).reshape(LAYER1_KERNEL_SHAPE)
+    layer2_weights = np.arange(1, np.prod(LAYER2_KERNEL_SHAPE) + 1, dtype=dtype).reshape(LAYER2_KERNEL_SHAPE)
+    return {
+        "input": input_data,
+        "layer1_weights": layer1_weights,
+        "layer2_weights": layer2_weights,
+    }
+
+
+def _build_program(payload_scale: float) -> Tuple[np.ndarray, Tuple[int, int, int], Tuple[int, int, int]]:
+    layer1_output_shape = _derive_output_shape(LAYER1_INPUT_SHAPE, LAYER1_KERNEL_SHAPE)
+    layer2_output_shape = _derive_output_shape(layer1_output_shape, LAYER2_KERNEL_SHAPE)
+
+    layer1_program = generate_cnn_workload(
+        LAYER1_INPUT_SHAPE, LAYER1_KERNEL_SHAPE, payload_scale=payload_scale
+    )
+    layer2_program = generate_cnn_workload(
+        layer1_output_shape, LAYER2_KERNEL_SHAPE, payload_scale=payload_scale
+    )
+    program = np.array([*layer1_program, *layer2_program, HALT_INSTRUCTION], dtype=np.uint32)
+    return program, layer1_output_shape, layer2_output_shape
+
+
+def _write_arrays(output_dir: Path, tensors: Dict[str, np.ndarray]) -> None:
+    for name, array in tensors.items():
+        target = output_dir / f"{name}.npy"
+        np.save(target, array)
+
+
+def _write_program(output_dir: Path, program: np.ndarray) -> None:
+    np.save(output_dir / "program.npy", program)
+
+
+def _write_metadata(output_dir: Path, metadata: CnnAssetMetadata) -> None:
+    target = output_dir / "metadata.json"
+    target.write_text(json.dumps(asdict(metadata), indent=2, sort_keys=True), encoding="utf-8")
+
+
+def generate_assets(output_dir: Path, *, payload_scale: float, dtype_name: str, force: bool) -> Path:
+    dtype = np.dtype(dtype_name)
+    _ensure_output_dir(output_dir, force=force)
+
+    tensors = _build_tensors(dtype)
+    program, layer1_output_shape, layer2_output_shape = _build_program(payload_scale)
+
+    _write_arrays(output_dir, tensors)
+    _write_program(output_dir, program)
+
+    metadata = CnnAssetMetadata(
+        layer1_input_shape=LAYER1_INPUT_SHAPE,
+        layer1_kernel_shape=LAYER1_KERNEL_SHAPE,
+        layer2_kernel_shape=LAYER2_KERNEL_SHAPE,
+        layer1_output_shape=layer1_output_shape,
+        layer2_output_shape=layer2_output_shape,
+        payload_scale=payload_scale,
+        halt_instruction=HALT_INSTRUCTION,
+        dtype=dtype.str,
+        program_length=int(program.size),
+    )
+    _write_metadata(output_dir, metadata)
+    return output_dir
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate deterministic tensor and program assets for the two-layer CNN scenario."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory where artifacts are written (default: workloads/generated/two_layer_cnn)",
+    )
+    parser.add_argument(
+        "--payload-scale",
+        type=float,
+        default=0.05,
+        help="Scale factor applied to the synthetic NOP payload (default: 0.05)",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="uint32",
+        help="NumPy dtype for the generated tensors (default: uint32)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing files under the output directory.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    output_dir = generate_assets(
+        args.output_dir,
+        payload_scale=max(args.payload_scale, 1e-6),
+        dtype_name=args.dtype,
+        force=args.force,
+    )
+    print(f"Generated two-layer CNN assets under {output_dir}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION

  - 작성·실행 가능한 CNN 자산 생성 CLI를 추가해 텐서/프로그램/메타
  데이터를 결정적으로 재구성하도록 했습니다 ia_risc_v_npu/workloads/
  generators/generate_two_layer_cnn_assets.py:1.
  - 워크로드 패키지에 생성기 모듈과 산출물 전용 gitignore를 도입해
  바이너리 추적을 차단했습니다 ia_risc_v_npu/workloads/generators/
  __init__.py:1, ia_risc_v_npu/workloads/generated/.gitignore:1.
  - 워크로드 README를 신설하고 CNN 자산 재생성 절차 및 체크리스트를 문
  서화했습니다 ia_risc_v_npu/workloads/README.md:1.
  - 개발 가이드와 개선 계획 문서에 자산 생성 플로우를 반영해 온보
  딩 가이드를 갱신했습니다 ia_risc_v_npu/docs/development.md:42,
  ia_risc_v_npu/docs/code_review_and_improvement_plan.md:81.
